### PR TITLE
Filter empty property names

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -3,7 +3,7 @@
 	"author": [
 		"Marijn van Wezel"
 	],
-	"version": "4.1.0",
+	"version": "4.1.1",
 	"url": "https://www.mediawiki.org/wiki/Extension:WikiSearch",
 	"descriptionmsg": "wikisearch-desc",
 	"license-name": "GPL-2.0-or-later",

--- a/src/SearchEngineConfig.php
+++ b/src/SearchEngineConfig.php
@@ -280,6 +280,7 @@ class SearchEngineConfig {
 				break;
 			case "propertyfieldlist":
 				$search_parameter_value = array_map( "trim", explode( ",", $search_parameter_value_raw ) );
+				$search_parameter_value = array_filter( $search_parameter_value, fn ( string $value ): bool => !empty( $value ) );
 				$search_parameter_value = array_map( function ( $property ): string {
 					// Map the property name to its field
 					return ( new PropertyFieldMapper( $property ) )->getPropertyField();
@@ -287,6 +288,7 @@ class SearchEngineConfig {
 				break;
 			case "propertylist":
 				$search_parameter_value = array_map( "trim", explode( ",", $search_parameter_value_raw ) );
+				$search_parameter_value = array_filter( $search_parameter_value, fn ( string $value ): bool => !empty( $value ) );
 				$search_parameter_value = array_map( function ( $property ): PropertyFieldMapper {
 					// Map the property name to its field
 					return ( new PropertyFieldMapper( $property ) );


### PR DESCRIPTION
This commit fixes an issue where WikiSearch would crash if an empty property name was given in either the `highlighted properties` or the `search term properties` parameter.