### PR TITLE
Add some predefined properties

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "php": "^7.4",
         "elasticsearch/elasticsearch": "^5.3|^6.0",
         "ongr/elasticsearch-dsl": "~6.0",
-        "composer/installers": "1.*,>=1.0.1"
+        "composer/installers": "1.*,>=1.0.1",
+        "paquettg/php-html-parser": "^3.1"
     },
     "require-dev": {
         "mediawiki/mediawiki-codesniffer": "34.0.0",

--- a/extension.json
+++ b/extension.json
@@ -41,7 +41,8 @@
 		"ArticleDeleteComplete": "WikiSearch\\WikiSearchHooks::onArticleDeleteComplete",
 		"PageContentSaveComplete": "WikiSearch\\WikiSearchHooks::onPageContentSaveComplete",
 		"LoadExtensionSchemaUpdates": "WikiSearch\\WikiSearchHooks::onLoadExtensionSchemaUpdates",
-		"BeforePageDisplay": "WikiSearch\\WikiSearchHooks::onBeforePageDisplay"
+		"BeforePageDisplay": "WikiSearch\\WikiSearchHooks::onBeforePageDisplay",
+		"SMW::Store::BeforeDataUpdateComplete": "WikiSearch\\WikiSearchHooks::onBeforeDataUpdateComplete"
 	},
 	"config": {
 		"WikiSearchElasticStoreIndex": {

--- a/extension.json
+++ b/extension.json
@@ -42,7 +42,8 @@
 		"PageContentSaveComplete": "WikiSearch\\WikiSearchHooks::onPageContentSaveComplete",
 		"LoadExtensionSchemaUpdates": "WikiSearch\\WikiSearchHooks::onLoadExtensionSchemaUpdates",
 		"BeforePageDisplay": "WikiSearch\\WikiSearchHooks::onBeforePageDisplay",
-		"SMW::Store::BeforeDataUpdateComplete": "WikiSearch\\WikiSearchHooks::onBeforeDataUpdateComplete"
+		"SMW::Store::BeforeDataUpdateComplete": "WikiSearch\\WikiSearchHooks::onBeforeDataUpdateComplete",
+		"SMW::Property::initProperties": "WikiSearch\\WikiSearchHooks::onInitProperties"
 	},
 	"config": {
 		"WikiSearchElasticStoreIndex": {

--- a/src/SMW/Annotators/AltTextAnnotator.php
+++ b/src/SMW/Annotators/AltTextAnnotator.php
@@ -39,14 +39,14 @@ class AltTextAnnotator implements Annotator {
      * @inheritDoc
      */
     public static function getId(): string {
-        return '__wikisearch_image_alt_text';
+        return '__wikisearch_image_alt_texts';
     }
 
     /**
      * @inheritDoc
      */
     public static function getLabel(): string {
-        return 'Image alt text';
+        return 'Image alt texts';
     }
 
     /**

--- a/src/SMW/Annotators/AltTextAnnotator.php
+++ b/src/SMW/Annotators/AltTextAnnotator.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace WikiSearch\SMW\Annotators;
+
+use Exception;
+use ParserOutput;
+use PHPHtmlParser\Dom;
+use PHPHtmlParser\Exceptions\ChildNotFoundException;
+use PHPHtmlParser\Exceptions\CircularException;
+use PHPHtmlParser\Exceptions\ContentLengthException;
+use PHPHtmlParser\Exceptions\LogicalException;
+use PHPHtmlParser\Exceptions\NotLoadedException;
+use PHPHtmlParser\Exceptions\StrictException;
+use SMW\DIProperty;
+use SMW\SemanticData;
+use SMWDIBlob;
+
+/**
+ * This annotator contains information about images "alt" attributes.
+ */
+class AltTextAnnotator implements Annotator {
+    /**
+     * @inheritDoc
+     */
+    public static function addAnnotation( ParserOutput $parserOutput, SemanticData $semanticData ): void {
+        // Get the HTML
+        $text = $parserOutput->getText();
+        $altTexts = self::getAltTexts( $text );
+
+        foreach ( $altTexts as $altText ) {
+            $semanticData->addPropertyObjectValue(
+                new DIProperty( self::getId() ),
+                new SMWDIBlob( $altText )
+            );
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getId(): string {
+        return '__wikisearch_image_alt_text';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getLabel(): string {
+        return 'Image alt text';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDefinition(): array {
+        return [
+            'label' => self::getLabel(),
+            'type' => '_txt',
+            'viewable' => true,
+            'annotable' => false
+        ];
+    }
+
+    /**
+     * Parses the given HTML and returns the alt texts.
+     *
+     * @param string $html
+     * @return array
+     */
+    private static function getAltTexts( string $html ): array {
+        // Parse the DOM
+        $dom = new Dom();
+
+        try {
+            $dom->loadStr($html);
+            $imgElements = $dom->find( 'img' );
+        } catch ( Exception $exception ) {
+            return [];
+        }
+
+        $altTexts = [];
+
+        foreach ( $imgElements as $element ) {
+            $altText = $element->getAttribute( 'alt' );
+
+            if ( $altText ) {
+                $altTexts[] = $altText;
+            }
+        }
+
+        return array_unique( $altTexts );
+    }
+}

--- a/src/SMW/Annotators/Annotator.php
+++ b/src/SMW/Annotators/Annotator.php
@@ -7,7 +7,9 @@ use SMW\SemanticData;
 
 interface Annotator {
     public const ANNOTATORS = [
-        AltTextAnnotator::class
+        AltTextAnnotator::class,
+        ImagesAnnotator::class,
+        LinksAnnotator::class
     ];
 
     /**

--- a/src/SMW/Annotators/Annotator.php
+++ b/src/SMW/Annotators/Annotator.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace WikiSearch\SMW\Annotators;
+
+use ParserOutput;
+use SMW\SemanticData;
+
+interface Annotator {
+    public const ANNOTATORS = [
+        AltTextAnnotator::class
+    ];
+
+    /**
+     * Analyze the given parser output and decorate the given semantic data object with the results.
+     *
+     * @param ParserOutput $parserOutput
+     * @param SemanticData $semanticData
+     */
+    public static function addAnnotation( ParserOutput $parserOutput, SemanticData $semanticData ): void;
+
+    /**
+     * Returns the ID of annotation that will be added.
+     *
+     * @return string
+     */
+    public static function getId(): string;
+
+    /**
+     * Returns the label of annotation that will be added.
+     *
+     * @return string
+     */
+    public static function getLabel(): string;
+
+    /**
+     * Returns the definition of the annotation that will be added.
+     *
+     * @return array
+     */
+    public static function getDefinition(): array;
+}

--- a/src/SMW/Annotators/Annotator.php
+++ b/src/SMW/Annotators/Annotator.php
@@ -9,7 +9,8 @@ interface Annotator {
     public const ANNOTATORS = [
         AltTextAnnotator::class,
         ImagesAnnotator::class,
-        LinksAnnotator::class
+        InternalLinksAnnotator::class,
+        ExternalLinksAnnotator::class
     ];
 
     /**

--- a/src/SMW/Annotators/ExternalLinksAnnotator.php
+++ b/src/SMW/Annotators/ExternalLinksAnnotator.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace WikiSearch\SMW\Annotators;
+
+use ParserOutput;
+use SMW\DIProperty;
+use SMW\SemanticData;
+use SMWDIBlob;
+use Title;
+
+/**
+ * This annotator contains information about external links that are used on a page.
+ */
+class ExternalLinksAnnotator implements Annotator {
+    /**
+     * @inheritDoc
+     */
+    public static function addAnnotation( ParserOutput $parserOutput, SemanticData $semanticData ): void {
+        $links = array_keys( $parserOutput->getExternalLinks() );
+
+        foreach ( $links as $link ) {
+            $semanticData->addPropertyObjectValue(
+                new DIProperty( self::getId() ),
+                new SMWDIBlob( $link )
+            );
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getId(): string {
+        return '__wikisearch_external_links';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getLabel(): string {
+        return 'External links';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDefinition(): array {
+        return [
+            'label' => self::getLabel(),
+            'type' => '_txt',
+            'viewable' => true,
+            'annotable' => false
+        ];
+    }
+}

--- a/src/SMW/Annotators/ImagesAnnotator.php
+++ b/src/SMW/Annotators/ImagesAnnotator.php
@@ -2,9 +2,7 @@
 
 namespace WikiSearch\SMW\Annotators;
 
-use Exception;
 use ParserOutput;
-use PHPHtmlParser\Dom;
 use SMW\DIProperty;
 use SMW\SemanticData;
 use SMWDIBlob;

--- a/src/SMW/Annotators/ImagesAnnotator.php
+++ b/src/SMW/Annotators/ImagesAnnotator.php
@@ -29,14 +29,14 @@ class ImagesAnnotator implements Annotator {
      * @inheritDoc
      */
     public static function getId(): string {
-        return '__wikisearch_image_link';
+        return '__wikisearch_image_links';
     }
 
     /**
      * @inheritDoc
      */
     public static function getLabel(): string {
-        return 'Image link';
+        return 'Image links';
     }
 
     /**

--- a/src/SMW/Annotators/ImagesAnnotator.php
+++ b/src/SMW/Annotators/ImagesAnnotator.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace WikiSearch\SMW\Annotators;
+
+use Exception;
+use ParserOutput;
+use PHPHtmlParser\Dom;
+use SMW\DIProperty;
+use SMW\SemanticData;
+use SMWDIBlob;
+
+/**
+ * This annotator contains information about images that are used on a page.
+ */
+class ImagesAnnotator implements Annotator {
+    /**
+     * @inheritDoc
+     */
+    public static function addAnnotation( ParserOutput $parserOutput, SemanticData $semanticData ): void {
+        $images = array_keys( $parserOutput->getImages() );
+
+        foreach ( $images as $image ) {
+            $semanticData->addPropertyObjectValue(
+                new DIProperty( self::getId() ),
+                new SMWDIBlob( $image )
+            );
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getId(): string {
+        return '__wikisearch_image_link';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getLabel(): string {
+        return 'Image link';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDefinition(): array {
+        return [
+            'label' => self::getLabel(),
+            'type' => '_txt',
+            'viewable' => true,
+            'annotable' => false
+        ];
+    }
+}

--- a/src/SMW/Annotators/InternalLinksAnnotator.php
+++ b/src/SMW/Annotators/InternalLinksAnnotator.php
@@ -9,9 +9,9 @@ use SMWDIBlob;
 use Title;
 
 /**
- * This annotator contains information about links that are used on a page.
+ * This annotator contains information about internal links that are used on a page.
  */
-class LinksAnnotator implements Annotator {
+class InternalLinksAnnotator implements Annotator {
     /**
      * @inheritDoc
      */
@@ -30,14 +30,14 @@ class LinksAnnotator implements Annotator {
      * @inheritDoc
      */
     public static function getId(): string {
-        return '__wikisearch_links';
+        return '__wikisearch_internal_links';
     }
 
     /**
      * @inheritDoc
      */
     public static function getLabel(): string {
-        return 'Links';
+        return 'Internal links';
     }
 
     /**

--- a/src/SMW/Annotators/LinksAnnotator.php
+++ b/src/SMW/Annotators/LinksAnnotator.php
@@ -30,14 +30,14 @@ class LinksAnnotator implements Annotator {
      * @inheritDoc
      */
     public static function getId(): string {
-        return '__wikisearch_image_link';
+        return '__wikisearch_links';
     }
 
     /**
      * @inheritDoc
      */
     public static function getLabel(): string {
-        return 'Image link';
+        return 'Links';
     }
 
     /**

--- a/src/SMW/Annotators/LinksAnnotator.php
+++ b/src/SMW/Annotators/LinksAnnotator.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace WikiSearch\SMW\Annotators;
+
+use ParserOutput;
+use SMW\DIProperty;
+use SMW\SemanticData;
+use SMWDIBlob;
+use Title;
+
+/**
+ * This annotator contains information about links that are used on a page.
+ */
+class LinksAnnotator implements Annotator {
+    /**
+     * @inheritDoc
+     */
+    public static function addAnnotation( ParserOutput $parserOutput, SemanticData $semanticData ): void {
+        $links = self::formatLinks( $parserOutput->getLinks() );
+
+        foreach ( $links as $link ) {
+            $semanticData->addPropertyObjectValue(
+                new DIProperty( self::getId() ),
+                new SMWDIBlob( $link )
+            );
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getId(): string {
+        return '__wikisearch_image_link';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getLabel(): string {
+        return 'Image link';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDefinition(): array {
+        return [
+            'label' => self::getLabel(),
+            'type' => '_txt',
+            'viewable' => true,
+            'annotable' => false
+        ];
+    }
+
+    /**
+     * Formats the result of the parser output getLinks function.
+     *
+     * @param $links
+     * @return array
+     */
+    private static function formatLinks( $links ): array {
+        $result = [];
+        foreach ( $links as $ns => $nsLinks ) {
+            foreach ( $nsLinks as $title => $id ) {
+                $result[] = Title::makeTitle( $ns, $title )->getFullText();
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/SMW/PropertyInitializer.php
+++ b/src/SMW/PropertyInitializer.php
@@ -3,6 +3,7 @@
 namespace WikiSearch\SMW;
 
 use SMW\PropertyRegistry;
+use WikiSearch\SMW\Annotators\Annotator;
 
 /**
  * Initializes the predefined properties that may be used for search.
@@ -67,7 +68,7 @@ class PropertyInitializer {
      */
     public function getPropertyDefinitions(): array {
         $definitions = [];
-        $annotators = AnnotatorStore::ANNOTATORS;
+        $annotators = Annotator::ANNOTATORS;
 
         foreach ( $annotators as $annotation ) {
             $definitions[$annotation::getId()] = $annotation::getDefinition();

--- a/src/SMW/PropertyInitializer.php
+++ b/src/SMW/PropertyInitializer.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace WikiSearch\SMW;
+
+use SMW\PropertyRegistry;
+
+/**
+ * Initializes the predefined properties that may be used for search.
+ */
+class PropertyInitializer {
+    /**
+     * @var PropertyRegistry The PropertyRegistry in which to initialise the predefined properties
+     */
+    private PropertyRegistry $registry;
+
+    /**
+     * @param PropertyRegistry $registry The PropertyRegistry in which to initialise the predefined properties
+     */
+    public function __construct( PropertyRegistry $registry ) {
+        $this->registry = $registry;
+    }
+
+    /**
+     * Initialize the predefined properties.
+     *
+     * @link https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/examples/hook.property.initproperties.md
+     */
+    public function initProperties(): void {
+        $definitions = $this->getPropertyDefinitions();
+
+        foreach ( $definitions as $propertyId => $definition ) {
+            $this->registry->registerProperty(
+                $propertyId,
+                $definition['type'],
+                $definition['label'] ?? false,
+                $definition['viewable'] ?? false,
+                $definition['annotable'] ?? true,
+                $definition['declarative'] ?? false
+            );
+
+            if ( isset( $definition['alias'] ) ) {
+                $this->registry->registerPropertyAlias(
+                    $propertyId,
+                    wfMessage( $definition['alias'] )->text()
+                );
+
+                $this->registry->registerPropertyAliasByMsgKey(
+                    $propertyId,
+                    $definition['alias']
+                );
+            }
+
+            if ( isset( $definition['description'] ) ) {
+                $this->registry->registerPropertyDescriptionByMsgKey(
+                    $propertyId,
+                    $definition['description']
+                );
+            }
+        }
+
+    }
+
+    /**
+     * Returns the property definitions of the predefined properties.
+     *
+     * @return array
+     */
+    public function getPropertyDefinitions(): array {
+        $definitions = [];
+        $annotators = AnnotatorStore::ANNOTATORS;
+
+        foreach ( $annotators as $annotation ) {
+            $definitions[$annotation::getId()] = $annotation::getDefinition();
+        }
+
+        return $definitions;
+    }
+}

--- a/src/WikiSearchHooks.php
+++ b/src/WikiSearchHooks.php
@@ -31,6 +31,7 @@ use OutputPage;
 use Parser;
 use Revision;
 use Skin;
+use SMW\PropertyRegistry;
 use SMW\SemanticData;
 use SMW\Store;
 use Status;
@@ -39,6 +40,7 @@ use User;
 use WikiPage;
 use WikiSearch\SMW\Annotators\Annotator;
 use WikiSearch\SMW\AnnotatorStore;
+use WikiSearch\SMW\PropertyInitializer;
 
 /**
  * Class SearchHooks
@@ -200,6 +202,18 @@ abstract class WikiSearchHooks {
 
 		exit();
 	}
+
+    /**
+     * Hook to add additional predefined properties.
+     *
+     * @param PropertyRegistry $propertyRegistry
+     * @return void
+     * @link https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/examples/hook.property.initproperties.md
+     */
+    public static function onInitProperties( PropertyRegistry $propertyRegistry ): void {
+        $propertyInitializer = new PropertyInitializer( $propertyRegistry );
+        $propertyInitializer->initProperties();
+    }
 
     /**
      * Hook to extend the SemanticData object before the update is completed.


### PR DESCRIPTION
This PR adds a mechanism for defining predefined properties which can be used in the search, and it adds the following predefined properties:

* `__wikisearch_image_alt_texts` (Image alt texts): All image “alt” texts on the page.
* `__wikisearch_image_links` (Image links): All links to images on the page.
* `__wikisearch_internal_links` (Internal links): All links to other pages on the page.
* `__wikisearch_external_links` (External links): All links to external pages on the page.