### PR TITLE
Make query preparation configurable in back-end

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -3,7 +3,7 @@
 	"author": [
 		"Marijn van Wezel"
 	],
-	"version": "6.0.1",
+	"version": "6.1.0",
 	"url": "https://www.mediawiki.org/wiki/Extension:WikiSearch",
 	"descriptionmsg": "wikisearch-desc",
 	"license-name": "GPL-2.0-or-later",
@@ -75,6 +75,9 @@
 		},
 		"WikiSearchMaxChainedQuerySize": {
 			"value": 500
+		},
+		"WikiSearchEscape": {
+			"value": false
 		}
 	},
 	"SpecialPages": {

--- a/src/QueryEngine/Filter/PropertyTextFilter.php
+++ b/src/QueryEngine/Filter/PropertyTextFilter.php
@@ -20,6 +20,8 @@ use WikiSearch\SMW\PropertyFieldMapper;
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html
  */
 class PropertyTextFilter extends PropertyFilter {
+    use QueryPreparationTrait;
+
 	/**
 	 * @var PropertyFieldMapper The property to filter on
 	 */
@@ -102,7 +104,7 @@ class PropertyTextFilter extends PropertyFilter {
 			$fields[] = $this->property->getWeightedSearchField();
 		}
 
-		$query_string_query = new QueryStringQuery( $this->property_value_query );
+		$query_string_query = new QueryStringQuery( $this->prepareQuery( $this->property_value_query ) );
 		$query_string_query->setParameters( [
 			"fields" => $fields,
 			"default_operator" => $this->default_operator

--- a/src/QueryEngine/Filter/PropertyTextFilter.php
+++ b/src/QueryEngine/Filter/PropertyTextFilter.php
@@ -20,7 +20,7 @@ use WikiSearch\SMW\PropertyFieldMapper;
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html
  */
 class PropertyTextFilter extends PropertyFilter {
-    use QueryPreparationTrait;
+	use QueryPreparationTrait;
 
 	/**
 	 * @var PropertyFieldMapper The property to filter on

--- a/src/QueryEngine/Filter/QueryPreparationTrait.php
+++ b/src/QueryEngine/Filter/QueryPreparationTrait.php
@@ -12,78 +12,78 @@ use MediaWiki\MediaWikiServices;
  * @package WikiSearch\QueryEngine\Filter
  */
 trait QueryPreparationTrait {
-    /**
-     * Prepares the query for use with ElasticSearch.
-     *
-     * @param string $search_term
-     * @return string
-     */
-    public function prepareQuery( string $search_term ): string {
-        if ( !MediaWikiServices::getInstance()->getMainConfig()->get( 'WikiSearchEscape' ) ) {
-            // Escaping in the back-end is disabled
-            return $search_term;
-        }
+	/**
+	 * Prepares the query for use with ElasticSearch.
+	 *
+	 * @param string $search_term
+	 * @return string
+	 */
+	public function prepareQuery( string $search_term ): string {
+		if ( !MediaWikiServices::getInstance()->getMainConfig()->get( 'WikiSearchEscape' ) ) {
+			// Escaping in the back-end is disabled
+			return $search_term;
+		}
 
-        $search_term = trim( $search_term );
-        $term_length = strlen( $search_term );
+		$search_term = trim( $search_term );
+		$term_length = strlen( $search_term );
 
-        if ( $term_length === 0 ) {
-            return "*";
-        }
+		if ( $term_length === 0 ) {
+			return "*";
+		}
 
-        // Disable regex searches by replacing each "/" with " "
-        $search_term = str_replace( "/", ' ', $search_term );
+		// Disable regex searches by replacing each "/" with " "
+		$search_term = str_replace( "/", ' ', $search_term );
 
-        // Disable certain search operators by escaping them
-        $search_term = str_replace( ":", '\:', $search_term );
-        $search_term = str_replace( "+", '\+', $search_term );
-        $search_term = str_replace( "=", '\=', $search_term );
+		// Disable certain search operators by escaping them
+		$search_term = str_replace( ":", '\:', $search_term );
+		$search_term = str_replace( "+", '\+', $search_term );
+		$search_term = str_replace( "=", '\=', $search_term );
 
-        // Don't insert wildcard around terms when the user is performing an "advanced query"
-        $advanced_search_chars = [ "\"", "'", "AND", "NOT", "OR", "~", "(", ")", "?", "*", " -" ];
-        $is_advanced_query = array_reduce( $advanced_search_chars, function ( bool $carry, $char ) use ( $search_term )
-        {
-            return $carry ?: strpos( $search_term, $char ) !== false;
-        }, false );
+		// Don't insert wildcard around terms when the user is performing an "advanced query"
+		$advanced_search_chars = [ "\"", "'", "AND", "NOT", "OR", "~", "(", ")", "?", "*", " -" ];
+		$is_advanced_query = array_reduce( $advanced_search_chars, function ( bool $carry, $char ) use ( $search_term )
+		{
+			return $carry ?: strpos( $search_term, $char ) !== false;
+		}, false );
 
-        if ( !$is_advanced_query ) {
-            $search_term = $this->insertWildcards( $search_term );
-        }
+		if ( !$is_advanced_query ) {
+			$search_term = $this->insertWildcards( $search_term );
+		}
 
-        return $search_term;
-    }
+		return $search_term;
+	}
 
-    /**
-     * Inserts wild cards around each term in the provided search string.
-     *
-     * @param string $search_string
-     * @return string
-     */
-    public function insertWildcards( string $search_string ): string {
-        $word_character_set = "a-zA-Z_\-0-9";
-        $terms = preg_split(
-            "/((?<=[$word_character_set])(?=$|[^$word_character_set])\s*)/",
-            $search_string,
-            -1,
-            PREG_SPLIT_DELIM_CAPTURE
-        );
+	/**
+	 * Inserts wild cards around each term in the provided search string.
+	 *
+	 * @param string $search_string
+	 * @return string
+	 */
+	public function insertWildcards( string $search_string ): string {
+		$word_character_set = "a-zA-Z_\-0-9";
+		$terms = preg_split(
+			"/((?<=[$word_character_set])(?=$|[^$word_character_set])\s*)/",
+			$search_string,
+			-1,
+			PREG_SPLIT_DELIM_CAPTURE
+		);
 
-        // $terms is now an array where every even element is a term (0 is a term, 2 is a term, etc.), and
-        // every odd element the delimiter between that term and the next term. Calling implode() on
-        // $terms gives back the original search string
+		// $terms is now an array where every even element is a term (0 is a term, 2 is a term, etc.), and
+		// every odd element the delimiter between that term and the next term. Calling implode() on
+		// $terms gives back the original search string
 
-        $num_terms = count( $terms );
+		$num_terms = count( $terms );
 
-        // Insert quotes around each term
-        for ( $idx = 0; $idx < $num_terms; $idx++ ) {
-            $is_term = ( $idx % 2 ) === 0 && !empty( $terms[$idx] );
+		// Insert quotes around each term
+		for ( $idx = 0; $idx < $num_terms; $idx++ ) {
+			$is_term = ( $idx % 2 ) === 0 && !empty( $terms[$idx] );
 
-            if ( $is_term ) {
-                $terms[$idx] = "*{$terms[$idx]}*";
-            }
-        }
+			if ( $is_term ) {
+				$terms[$idx] = "*{$terms[$idx]}*";
+			}
+		}
 
-        // Join everything together again to get the search string
-        return implode( "", $terms );
-    }
+		// Join everything together again to get the search string
+		return implode( "", $terms );
+	}
 }

--- a/src/QueryEngine/Filter/QueryPreparationTrait.php
+++ b/src/QueryEngine/Filter/QueryPreparationTrait.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace WikiSearch\QueryEngine\Filter;
+
+use MediaWiki\MediaWikiServices;
+
+/**
+ * Trait QueryPreparationTrait
+ *
+ * This trait contains a method that can be used to prepare bare queries for use with ElasticSearch.
+ *
+ * @package WikiSearch\QueryEngine\Filter
+ */
+trait QueryPreparationTrait {
+    /**
+     * Prepares the query for use with ElasticSearch.
+     *
+     * @param string $search_term
+     * @return string
+     */
+    public function prepareQuery( string $search_term ): string {
+        if ( !MediaWikiServices::getInstance()->getMainConfig()->get( 'WikiSearchEscape' ) ) {
+            // Escaping in the back-end is disabled
+            return $search_term;
+        }
+
+        $search_term = trim( $search_term );
+        $term_length = strlen( $search_term );
+
+        if ( $term_length === 0 ) {
+            return "*";
+        }
+
+        // Disable regex searches by replacing each "/" with " "
+        $search_term = str_replace( "/", ' ', $search_term );
+
+        // Disable certain search operators by escaping them
+        $search_term = str_replace( ":", '\:', $search_term );
+        $search_term = str_replace( "+", '\+', $search_term );
+        $search_term = str_replace( "=", '\=', $search_term );
+
+        // Don't insert wildcard around terms when the user is performing an "advanced query"
+        $advanced_search_chars = [ "\"", "'", "AND", "NOT", "OR", "~", "(", ")", "?", "*", " -" ];
+        $is_advanced_query = array_reduce( $advanced_search_chars, function ( bool $carry, $char ) use ( $search_term )
+        {
+            return $carry ?: strpos( $search_term, $char ) !== false;
+        }, false );
+
+        if ( !$is_advanced_query ) {
+            $search_term = $this->insertWildcards( $search_term );
+        }
+
+        return $search_term;
+    }
+
+    /**
+     * Inserts wild cards around each term in the provided search string.
+     *
+     * @param string $search_string
+     * @return string
+     */
+    public function insertWildcards( string $search_string ): string {
+        $word_character_set = "a-zA-Z_\-0-9";
+        $terms = preg_split(
+            "/((?<=[$word_character_set])(?=$|[^$word_character_set])\s*)/",
+            $search_string,
+            -1,
+            PREG_SPLIT_DELIM_CAPTURE
+        );
+
+        // $terms is now an array where every even element is a term (0 is a term, 2 is a term, etc.), and
+        // every odd element the delimiter between that term and the next term. Calling implode() on
+        // $terms gives back the original search string
+
+        $num_terms = count( $terms );
+
+        // Insert quotes around each term
+        for ( $idx = 0; $idx < $num_terms; $idx++ ) {
+            $is_term = ( $idx % 2 ) === 0 && !empty( $terms[$idx] );
+
+            if ( $is_term ) {
+                $terms[$idx] = "*{$terms[$idx]}*";
+            }
+        }
+
+        // Join everything together again to get the search string
+        return implode( "", $terms );
+    }
+}

--- a/src/QueryEngine/Filter/SearchTermFilter.php
+++ b/src/QueryEngine/Filter/SearchTermFilter.php
@@ -12,6 +12,8 @@ use WikiSearch\SMW\PropertyFieldMapper;
  * @package WikiSearch\QueryEngine\Filter
  */
 class SearchTermFilter extends AbstractFilter {
+    use QueryPreparationTrait;
+
 	/**
 	 * @var PropertyFieldMapper[]
 	 */
@@ -82,16 +84,17 @@ class SearchTermFilter extends AbstractFilter {
 	 * @inheritDoc
 	 */
 	public function filterToQuery(): BoolQuery {
+        $search_term = $this->prepareQuery( $this->search_term );
 		$bool_query = new BoolQuery();
 
 		foreach ( $this->chained_properties as $property ) {
 			// Construct a new chained sub query for each chained property and add it to the bool query
-			$filter = new ChainedPropertyFilter( new PropertyTextFilter( $property, $this->search_term, $this->default_operator ) );
+			$filter = new ChainedPropertyFilter( new PropertyTextFilter( $property, $search_term, $this->default_operator ) );
 			$bool_query->add( $filter->toQuery(), BoolQuery::SHOULD );
 		}
 
 		if ( $this->property_fields !== [] ) {
-			$query_string_query = new QueryStringQuery( $this->search_term );
+			$query_string_query = new QueryStringQuery( $search_term );
 			$query_string_query->setParameters( [
 				"fields" => $this->property_fields,
 				"default_operator" => $this->default_operator,

--- a/src/QueryEngine/Filter/SearchTermFilter.php
+++ b/src/QueryEngine/Filter/SearchTermFilter.php
@@ -12,7 +12,7 @@ use WikiSearch\SMW\PropertyFieldMapper;
  * @package WikiSearch\QueryEngine\Filter
  */
 class SearchTermFilter extends AbstractFilter {
-    use QueryPreparationTrait;
+	use QueryPreparationTrait;
 
 	/**
 	 * @var PropertyFieldMapper[]
@@ -84,7 +84,7 @@ class SearchTermFilter extends AbstractFilter {
 	 * @inheritDoc
 	 */
 	public function filterToQuery(): BoolQuery {
-        $search_term = $this->prepareQuery( $this->search_term );
+		$search_term = $this->prepareQuery( $this->search_term );
 		$bool_query = new BoolQuery();
 
 		foreach ( $this->chained_properties as $property ) {


### PR DESCRIPTION
Previously (a065ceadcc4180a2013ce8fe1f71b97a978f09ec), query preparation was completely removed from the backend. This was deemed undesirable for some wiki's, so it is now configurable.