### PR TITLE
hotfix - wildcard selector for noindex hook

### DIFF
--- a/src/SMW/Annotators/ParsedTextAnnotator.php
+++ b/src/SMW/Annotators/ParsedTextAnnotator.php
@@ -78,7 +78,7 @@ class ParsedTextAnnotator implements Annotator {
         $selector = new \DOMXPath( $dom );
 
         // Filter out div elements with the class "smw-no-index"
-        $query = $selector->query( '//div[contains(attribute::class, "smw-no-index")]' );
+        $query = $selector->query( '//*[contains(attribute::class, "smw-no-index")]' );
         foreach ( $query as $element ) {
             $element->parentNode->removeChild( $element );
         }


### PR DESCRIPTION
allow all elements with the dedicated smw-no-index class to be removed from indexing, instead of only the built div from the parser