### PR TITLE
Add support for fuzzy searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,37 @@ The above filter executes the given query and only includes pages that matched t
 
 See also: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html
 
+#### PropertyFuzzyValueFilter
+
+This filter only returns pages that have the specified property with approximately the specified value.
+
+```
+{
+    "key": "Class",
+    "value": "Manual",
+    "type": "fuzzy"
+}
+```
+
+The above filter only includes pages where the property `Class` has a value similar to `Manual`. The `value` must be
+a string.
+
+Additionally, the maximum edit distance can be specified through the `fuzziness` parameter:
+
+```
+{
+    "key": "Class",
+    "value": "Manual",
+    "type": "fuzzy",
+    "fuzziness": 6
+}
+```
+
+`fuzziness` must either be the string "AUTO" to automatically determine the appropriate fuzziness (default), or
+a positive integer specifying the maximum edit distance.
+
+See also: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-fuzzy-query.html
+
 ### Aggregations syntax
 
 The `aggregations` parameter takes a list of objects. These objects have the following form:

--- a/src/QueryEngine/Factory/FilterFactory.php
+++ b/src/QueryEngine/Factory/FilterFactory.php
@@ -155,7 +155,7 @@ class FilterFactory {
 		array $array,
 		PropertyFieldMapper $property_field_mapper,
 		SearchEngineConfig $config
-	): ?PropertyTextFilter {
+	): ?PropertyFilter {
 		switch ( $type ) {
 			case "query":
 				if ( !isset( $array["value"] ) || !is_string( $array["value"] ) ) {

--- a/src/QueryEngine/Factory/FilterFactory.php
+++ b/src/QueryEngine/Factory/FilterFactory.php
@@ -52,9 +52,9 @@ class FilterFactory {
 
 		$filter = self::filterFromArray( $array, $property_field_mapper, $config );
 
-        if ( $filter === null ) {
-            return null;
-        }
+		if ( $filter === null ) {
+			return null;
+		}
 
 		if ( in_array( $array["key"], $config->getSearchParameter( "post filter properties" ), true ) ) {
 			$filter->setPostFilter();
@@ -171,22 +171,22 @@ class FilterFactory {
 				$default_operator = $config->getSearchParameter( "default operator" ) === "and" ?
 					"and" : "or";
 				return self::propertyTextFilterFromText( $array["value"], $default_operator, $property_field_mapper );
-            case "fuzzy":
-                if ( !isset( $array["value"] ) || !is_string( $array["value"] ) ) {
-                    Logger::getLogger()->debug( 'Failed to construct Filter from array: missing/invalid "value"' );
+			case "fuzzy":
+				if ( !isset( $array["value"] ) || !is_string( $array["value"] ) ) {
+					Logger::getLogger()->debug( 'Failed to construct Filter from array: missing/invalid "value"' );
 
-                    return null;
-                }
+					return null;
+				}
 
-                $fuzziness = $array["fuzziness"] ?? "AUTO";
+				$fuzziness = $array["fuzziness"] ?? "AUTO";
 
-                if ( $fuzziness !== "AUTO" &&  ( !is_int( $fuzziness ) || $fuzziness < 0 ) ) {
-                    Logger::getLogger()->debug( 'Failed to construct Filter from array: invalid "fuzziness"' );
+				if ( $fuzziness !== "AUTO" && ( !is_int( $fuzziness ) || $fuzziness < 0 ) ) {
+					Logger::getLogger()->debug( 'Failed to construct Filter from array: invalid "fuzziness"' );
 
-                    return null;
-                }
+					return null;
+				}
 
-                return self::propertyFuzzyValueFilterFromText( $array["value"], $fuzziness, $property_field_mapper );
+				return self::propertyFuzzyValueFilterFromText( $array["value"], $fuzziness, $property_field_mapper );
 			default:
 				Logger::getLogger()->debug( 'Failed to construct Filter from array: invalid "type"' );
 
@@ -256,17 +256,17 @@ class FilterFactory {
 		return new PropertyValuesFilter( $property_field_mapper, $values );
 	}
 
-    /**
-     * @param string $value
-     * @param string|int $fuzziness
-     * @param PropertyFieldMapper $property_field_mapper
-     * @return PropertyFuzzyValueFilter
-     */
-    private static function propertyFuzzyValueFilterFromText(
-        string $value,
-        $fuzziness,
-        PropertyFieldMapper $property_field_mapper
-    ): PropertyFuzzyValueFilter {
-        return new PropertyFuzzyValueFilter( $property_field_mapper, $value, $fuzziness );
-    }
+	/**
+	 * @param string $value
+	 * @param string|int $fuzziness
+	 * @param PropertyFieldMapper $property_field_mapper
+	 * @return PropertyFuzzyValueFilter
+	 */
+	private static function propertyFuzzyValueFilterFromText(
+		string $value,
+		$fuzziness,
+		PropertyFieldMapper $property_field_mapper
+	): PropertyFuzzyValueFilter {
+		return new PropertyFuzzyValueFilter( $property_field_mapper, $value, $fuzziness );
+	}
 }

--- a/src/QueryEngine/Factory/FilterFactory.php
+++ b/src/QueryEngine/Factory/FilterFactory.php
@@ -52,6 +52,10 @@ class FilterFactory {
 
 		$filter = self::filterFromArray( $array, $property_field_mapper, $config );
 
+        if ( $filter === null ) {
+            return null;
+        }
+
 		if ( in_array( $array["key"], $config->getSearchParameter( "post filter properties" ), true ) ) {
 			$filter->setPostFilter();
 		}
@@ -60,7 +64,7 @@ class FilterFactory {
 			$filter->setNegated();
 		}
 
-		if ( $filter !== null && $property_field_mapper->isChained() ) {
+		if ( $property_field_mapper->isChained() ) {
 			$filter = new ChainedPropertyFilter( $filter );
 		}
 

--- a/src/QueryEngine/Factory/FilterFactory.php
+++ b/src/QueryEngine/Factory/FilterFactory.php
@@ -18,6 +18,8 @@ use WikiSearch\SMW\PropertyFieldMapper;
 /**
  * Class FilterFactory
  *
+ * TODO: Rewrite this relatively messy parser and add appropriate error messages.
+ *
  * @package WikiSearch\QueryEngine\Factory
  */
 class FilterFactory {

--- a/src/QueryEngine/Factory/FilterFactory.php
+++ b/src/QueryEngine/Factory/FilterFactory.php
@@ -7,6 +7,7 @@ use WikiSearch\QueryEngine\Filter\AbstractFilter;
 use WikiSearch\QueryEngine\Filter\ChainedPropertyFilter;
 use WikiSearch\QueryEngine\Filter\HasPropertyFilter;
 use WikiSearch\QueryEngine\Filter\PropertyFilter;
+use WikiSearch\QueryEngine\Filter\PropertyFuzzyValueFilter;
 use WikiSearch\QueryEngine\Filter\PropertyRangeFilter;
 use WikiSearch\QueryEngine\Filter\PropertyTextFilter;
 use WikiSearch\QueryEngine\Filter\PropertyValueFilter;
@@ -145,7 +146,7 @@ class FilterFactory {
 	 * @param array $array
 	 * @param PropertyFieldMapper $property_field_mapper
 	 * @param SearchEngineConfig $config
-	 * @return PropertyTextFilter|null
+	 * @return PropertyTextFilter|PropertyFuzzyValueFilter|null
 	 */
 	private static function typeFilterFromArray(
 		string $type,
@@ -164,6 +165,22 @@ class FilterFactory {
 				$default_operator = $config->getSearchParameter( "default operator" ) === "and" ?
 					"and" : "or";
 				return self::propertyTextFilterFromText( $array["value"], $default_operator, $property_field_mapper );
+            case "fuzzy":
+                if ( !isset( $array["value"] ) || !is_string( $array["value"] ) ) {
+                    Logger::getLogger()->debug( 'Failed to construct Filter from array: missing/invalid "value"' );
+
+                    return null;
+                }
+
+                $fuzziness = $array["fuzziness"] ?? "AUTO";
+
+                if ( $fuzziness !== "AUTO" &&  ( !is_int( $fuzziness ) || $fuzziness < 0 ) ) {
+                    Logger::getLogger()->debug( 'Failed to construct Filter from array: invalid "fuzziness"' );
+
+                    return null;
+                }
+
+                return self::propertyFuzzyValueFilterFromText( $array["value"], $fuzziness, $property_field_mapper );
 			default:
 				Logger::getLogger()->debug( 'Failed to construct Filter from array: invalid "type"' );
 
@@ -232,4 +249,18 @@ class FilterFactory {
 	): PropertyValuesFilter {
 		return new PropertyValuesFilter( $property_field_mapper, $values );
 	}
+
+    /**
+     * @param string $value
+     * @param string|int $fuzziness
+     * @param PropertyFieldMapper $property_field_mapper
+     * @return PropertyFuzzyValueFilter
+     */
+    private static function propertyFuzzyValueFilterFromText(
+        string $value,
+        $fuzziness,
+        PropertyFieldMapper $property_field_mapper
+    ): PropertyFuzzyValueFilter {
+        return new PropertyFuzzyValueFilter( $property_field_mapper, $value, $fuzziness );
+    }
 }

--- a/src/QueryEngine/Filter/PropertyFuzzyValueFilter.php
+++ b/src/QueryEngine/Filter/PropertyFuzzyValueFilter.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace WikiSearch\QueryEngine\Filter;
+
+use InvalidArgumentException;
+use ONGR\ElasticsearchDSL\Query\Compound\BoolQuery;
+use ONGR\ElasticsearchDSL\Query\TermLevel\FuzzyQuery;
+use WikiSearch\Logger;
+use WikiSearch\SMW\PropertyFieldMapper;
+
+/**
+ * Class PropertyFuzzyValueFilter
+ *
+ * Filters pages based on the values of their properties using fuzzy matching. This filter does not take
+ * property chains into account.
+ *
+ * @see ChainedPropertyFilter for a filter that takes property chains into account
+ *
+ * @package WikiSearch\QueryEngine\Filter
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-fuzzy-query.html
+ */
+class PropertyFuzzyValueFilter extends PropertyFilter {
+	/**
+	 * @var PropertyFieldMapper The property to filter on
+	 */
+	private PropertyFieldMapper $property;
+
+    /**
+     * @var string|int The fuzziness to use, or "AUTO"
+     */
+    private $fuzziness;
+
+	/**
+	 * @var mixed The value the property to filter on
+	 */
+	private $property_value;
+
+	/**
+	 * PropertyFuzzyValueFilter constructor.
+	 *
+	 * @param PropertyFieldMapper|string $property The name or object of the property to filter on
+	 * @param string $property_value The value the property to filter on
+     * @param string|int $fuzziness The fuzziness to use, or "AUTO"
+	 */
+	public function __construct( $property, string $property_value, $fuzziness = "AUTO" ) {
+		if ( is_string( $property ) ) {
+			$property = new PropertyFieldMapper( $property );
+		}
+
+		if ( !( $property instanceof PropertyFieldMapper ) ) {
+			Logger::getLogger()->critical(
+				'Tried to construct a PropertyFuzzyValueFilter with an invalid property: {property}',
+				[
+					'property' => $property
+				]
+			);
+
+			throw new InvalidArgumentException( '$property must be of type string or PropertyFieldMapper' );
+		}
+
+        if ( $fuzziness !== "AUTO" && ( !is_int( $fuzziness ) || $fuzziness < 0 ) ) {
+            Logger::getLogger()->critical(
+                'Tried to construct a PropertyFuzzyValueFilter with an invalid fuzziness parameter: {fuzziness}',
+                [
+                    'fuzziness' => $fuzziness
+                ]
+            );
+
+            throw new InvalidArgumentException(
+                '$fuzziness must be "AUTO" or a positive integer'
+            );
+        }
+
+		$this->property = $property;
+		$this->property_value = $property_value;
+        $this->fuzziness = $fuzziness;
+	}
+
+	/**
+	 * Returns the property field mapper corresponding to this filter.
+	 *
+	 * @return PropertyFieldMapper
+	 */
+	public function getProperty(): PropertyFieldMapper {
+		return $this->property;
+	}
+
+	/**
+	 * Sets the property this filter will filter on.
+	 *
+	 * @param PropertyFieldMapper $property
+	 */
+	public function setPropertyName( PropertyFieldMapper $property ): void {
+		$this->property = $property;
+	}
+
+	/**
+	 * Sets the value of the property this filter will filter on.
+	 *
+	 * @param string $property_value
+	 */
+	public function setPropertyValue( string $property_value ): void {
+		$this->property_value = $property_value;
+	}
+
+    /**
+     * Sets the value of the fuzziness parameter this filter will use.
+     *
+     * @param string|int $fuzziness The fuzziness to use, or "AUTO"
+     * @return void
+     */
+    public function setFuzziness( $fuzziness ): void {
+        if ( $fuzziness !== "AUTO" && ( !is_int( $fuzziness ) || $fuzziness < 0 ) ) {
+            Logger::getLogger()->critical(
+                'Tried to set an invalid value for fuzziness: {fuzziness}',
+                [
+                    'fuzziness' => $fuzziness
+                ]
+            );
+
+            throw new InvalidArgumentException(
+                '$fuzziness must be "AUTO" or a positive integer'
+            );
+        }
+    }
+
+	/**
+	 * Converts the object to a BuilderInterface for use in the QueryEngine.
+	 *
+	 * @return BoolQuery
+	 */
+	public function filterToQuery(): BoolQuery {
+		$field = $this->property->hasKeywordSubfield() ?
+			$this->property->getKeywordField() :
+			$this->property->getPropertyField();
+
+        $parameters = [
+            "fuzziness" => $this->fuzziness
+        ];
+
+        $fuzzy_query = new FuzzyQuery( $field, $this->property_value, $parameters );
+
+		$bool_query = new BoolQuery();
+		$bool_query->add( $fuzzy_query, BoolQuery::FILTER );
+
+		/*
+		 * Example of such a query:
+		 *
+		 *  "bool": {
+		 *      "filter": {
+		 *          "fuzzy": {
+		 *              "P:0.wpgID": 0
+		 *          }
+		 *      }
+		 *  }
+		 */
+
+		return $bool_query;
+	}
+}

--- a/src/QueryEngine/Filter/PropertyFuzzyValueFilter.php
+++ b/src/QueryEngine/Filter/PropertyFuzzyValueFilter.php
@@ -25,10 +25,10 @@ class PropertyFuzzyValueFilter extends PropertyFilter {
 	 */
 	private PropertyFieldMapper $property;
 
-    /**
-     * @var string|int The fuzziness to use, or "AUTO"
-     */
-    private $fuzziness;
+	/**
+	 * @var string|int The fuzziness to use, or "AUTO"
+	 */
+	private $fuzziness;
 
 	/**
 	 * @var mixed The value the property to filter on
@@ -40,7 +40,7 @@ class PropertyFuzzyValueFilter extends PropertyFilter {
 	 *
 	 * @param PropertyFieldMapper|string $property The name or object of the property to filter on
 	 * @param string $property_value The value the property to filter on
-     * @param string|int $fuzziness The fuzziness to use, or "AUTO"
+	 * @param string|int $fuzziness The fuzziness to use, or "AUTO"
 	 */
 	public function __construct( $property, string $property_value, $fuzziness = "AUTO" ) {
 		if ( is_string( $property ) ) {
@@ -58,22 +58,22 @@ class PropertyFuzzyValueFilter extends PropertyFilter {
 			throw new InvalidArgumentException( '$property must be of type string or PropertyFieldMapper' );
 		}
 
-        if ( $fuzziness !== "AUTO" && ( !is_int( $fuzziness ) || $fuzziness < 0 ) ) {
-            Logger::getLogger()->critical(
-                'Tried to construct a PropertyFuzzyValueFilter with an invalid fuzziness parameter: {fuzziness}',
-                [
-                    'fuzziness' => $fuzziness
-                ]
-            );
+		if ( $fuzziness !== "AUTO" && ( !is_int( $fuzziness ) || $fuzziness < 0 ) ) {
+			Logger::getLogger()->critical(
+				'Tried to construct a PropertyFuzzyValueFilter with an invalid fuzziness parameter: {fuzziness}',
+				[
+					'fuzziness' => $fuzziness
+				]
+			);
 
-            throw new InvalidArgumentException(
-                '$fuzziness must be "AUTO" or a positive integer'
-            );
-        }
+			throw new InvalidArgumentException(
+				'$fuzziness must be "AUTO" or a positive integer'
+			);
+		}
 
 		$this->property = $property;
 		$this->property_value = $property_value;
-        $this->fuzziness = $fuzziness;
+		$this->fuzziness = $fuzziness;
 	}
 
 	/**
@@ -103,26 +103,26 @@ class PropertyFuzzyValueFilter extends PropertyFilter {
 		$this->property_value = $property_value;
 	}
 
-    /**
-     * Sets the value of the fuzziness parameter this filter will use.
-     *
-     * @param string|int $fuzziness The fuzziness to use, or "AUTO"
-     * @return void
-     */
-    public function setFuzziness( $fuzziness ): void {
-        if ( $fuzziness !== "AUTO" && ( !is_int( $fuzziness ) || $fuzziness < 0 ) ) {
-            Logger::getLogger()->critical(
-                'Tried to set an invalid value for fuzziness: {fuzziness}',
-                [
-                    'fuzziness' => $fuzziness
-                ]
-            );
+	/**
+	 * Sets the value of the fuzziness parameter this filter will use.
+	 *
+	 * @param string|int $fuzziness The fuzziness to use, or "AUTO"
+	 * @return void
+	 */
+	public function setFuzziness( $fuzziness ): void {
+		if ( $fuzziness !== "AUTO" && ( !is_int( $fuzziness ) || $fuzziness < 0 ) ) {
+			Logger::getLogger()->critical(
+				'Tried to set an invalid value for fuzziness: {fuzziness}',
+				[
+					'fuzziness' => $fuzziness
+				]
+			);
 
-            throw new InvalidArgumentException(
-                '$fuzziness must be "AUTO" or a positive integer'
-            );
-        }
-    }
+			throw new InvalidArgumentException(
+				'$fuzziness must be "AUTO" or a positive integer'
+			);
+		}
+	}
 
 	/**
 	 * Converts the object to a BuilderInterface for use in the QueryEngine.
@@ -134,11 +134,11 @@ class PropertyFuzzyValueFilter extends PropertyFilter {
 			$this->property->getKeywordField() :
 			$this->property->getPropertyField();
 
-        $parameters = [
-            "fuzziness" => $this->fuzziness
-        ];
+		$parameters = [
+			"fuzziness" => $this->fuzziness
+		];
 
-        $fuzzy_query = new FuzzyQuery( $field, $this->property_value, $parameters );
+		$fuzzy_query = new FuzzyQuery( $field, $this->property_value, $parameters );
 
 		$bool_query = new BoolQuery();
 		$bool_query->add( $fuzzy_query, BoolQuery::FILTER );

--- a/src/Scribunto/ScribuntoLuaLibrary.php
+++ b/src/Scribunto/ScribuntoLuaLibrary.php
@@ -23,116 +23,112 @@ namespace WikiSearch\Scribunto;
 
 use Elasticsearch\ClientBuilder;
 use MWException;
-use TextContent;
-use WikibaseSolutions\MediaWikiTemplateParser\RecursiveParser;
 use WikiSearch\QueryEngine\Aggregation\FilterAggregation;
 use WikiSearch\QueryEngine\Aggregation\PropertyValueAggregation;
 use WikiSearch\QueryEngine\Factory\QueryEngineFactory;
 use WikiSearch\QueryEngine\Filter\PropertyRangeFilter;
-use WSSlots\WikiPageTrait;
-use WSSlots\WSSlots;
 
 /**
  * Register the Lua library.
  */
 class ScribuntoLuaLibrary extends \Scribunto_LuaLibraryBase {
-    /**
-     * @inheritDoc
-     */
-    public function register(): void {
-        $interfaceFuncs = [
-            'propValues' => [ $this, 'propValues' ]
-        ];
+	/**
+	 * @inheritDoc
+	 */
+	public function register(): void {
+		$interfaceFuncs = [
+			'propValues' => [ $this, 'propValues' ]
+		];
 
-        $this->getEngine()->registerInterface( __DIR__ . '/' . 'mw.wikisearch.lua', $interfaceFuncs, [] );
-    }
+		$this->getEngine()->registerInterface( __DIR__ . '/' . 'mw.wikisearch.lua', $interfaceFuncs, [] );
+	}
 
-    /**
-     * This mirrors the functionality of the #prop_values parser function and makes it available in Lua.
-     *
-     * @param array $properties
-     * @return array
-     * @throws MWException
-     */
-    public function propValues( array $properties ): array {
-        $limit = $properties["limit"] ?? 100;
-        $property = $properties["property"] ?? "";
-        $dateProperty = $properties["date property"] ?? "Modification date";
-        $from = $properties["from"] ?? 1;
-        $to = $properties["to"] ?? 5000;
-        $baseQuery = $properties["query"] ?? null;
+	/**
+	 * This mirrors the functionality of the #prop_values parser function and makes it available in Lua.
+	 *
+	 * @param array $properties
+	 * @return array
+	 * @throws MWException
+	 */
+	public function propValues( array $properties ): array {
+		$limit = $properties["limit"] ?? 100;
+		$property = $properties["property"] ?? "";
+		$dateProperty = $properties["date property"] ?? "Modification date";
+		$from = $properties["from"] ?? 1;
+		$to = $properties["to"] ?? 5000;
+		$baseQuery = $properties["query"] ?? null;
 
-        if ( !$property || !is_int( $limit ) || !is_int( $from ) || !is_int( $to ) ) {
-            return [ null ];
-        }
+		if ( !$property || !is_int( $limit ) || !is_int( $from ) || !is_int( $to ) ) {
+			return [ null ];
+		}
 
-        if (
-            $from < 0 || $from > 9999 || // From range check
-            $to < 0 || $to > 9999 || // To range check
-            $to <= $from || // To-from order check
-            $limit < 1 || $limit > 9999 // Limit range check
-        ) {
-            return [ null ];
-        }
+		if (
+			$from < 0 || $from > 9999 || // From range check
+			$to < 0 || $to > 9999 || // To range check
+			$to <= $from || // To-from order check
+			$limit < 1 || $limit > 9999 // Limit range check
+		) {
+			return [ null ];
+		}
 
-        list( $from, $to ) = $this->convertDates( $from, $to );
+		list( $from, $to ) = $this->convertDates( $from, $to );
 
-        $rangeFilter = new PropertyRangeFilter( $dateProperty, [ "to" => $to, "from" => $from ] );
-        $termsAggregation = new PropertyValueAggregation( $property, "common_values", $limit );
-        $aggregation = new FilterAggregation( $rangeFilter, [ $termsAggregation ], "property_values" );
+		$rangeFilter = new PropertyRangeFilter( $dateProperty, [ "to" => $to, "from" => $from ] );
+		$termsAggregation = new PropertyValueAggregation( $property, "common_values", $limit );
+		$aggregation = new FilterAggregation( $rangeFilter, [ $termsAggregation ], "property_values" );
 
-        $queryEngine = QueryEngineFactory::fromNull();
-        $queryEngine->addAggregation( $aggregation );
+		$queryEngine = QueryEngineFactory::fromNull();
+		$queryEngine->addAggregation( $aggregation );
 
-        if ( isset( $baseQuery ) ) {
-            $queryEngine->setBaseQuery( $baseQuery );
-        }
+		if ( isset( $baseQuery ) ) {
+			$queryEngine->setBaseQuery( $baseQuery );
+		}
 
-        $results = ClientBuilder::create()
-            ->setHosts( QueryEngineFactory::fromNull()->getElasticHosts() )
-            ->build()
-            ->search( $queryEngine->toArray() );
+		$results = ClientBuilder::create()
+			->setHosts( QueryEngineFactory::fromNull()->getElasticHosts() )
+			->build()
+			->search( $queryEngine->toArray() );
 
-        if ( !isset( $results["aggregations"]["property_values"]["property_values"]["common_values"]["buckets"] ) ) {
-            // Failed to create aggregations
-            return [ null ];
-        }
+		if ( !isset( $results["aggregations"]["property_values"]["property_values"]["common_values"]["buckets"] ) ) {
+			// Failed to create aggregations
+			return [ null ];
+		}
 
-        $buckets = $results["aggregations"]["property_values"]["property_values"]["common_values"]["buckets"];
+		$buckets = $results["aggregations"]["property_values"]["property_values"]["common_values"]["buckets"];
 
-        if ( !is_array( $buckets ) ) {
-            // The aggregations are not valid
-            return [ null ];
-        }
+		if ( !is_array( $buckets ) ) {
+			// The aggregations are not valid
+			return [ null ];
+		}
 
-        return [ $this->convertToLuaTable( $buckets ) ];
-    }
+		return [ $this->convertToLuaTable( $buckets ) ];
+	}
 
-    /**
-     * Converts the given dates to Julian dates.
-     *
-     * @param int $from_year
-     * @param int $to_year
-     * @return array
-     */
-    private function convertDates( int $from_year, int $to_year ): array {
-        return [ gregoriantojd( 1, 1, $from_year ), gregoriantojd( 12, 31, $to_year ) ];
-    }
+	/**
+	 * Converts the given dates to Julian dates.
+	 *
+	 * @param int $from_year
+	 * @param int $to_year
+	 * @return array
+	 */
+	private function convertDates( int $from_year, int $to_year ): array {
+		return [ gregoriantojd( 1, 1, $from_year ), gregoriantojd( 12, 31, $to_year ) ];
+	}
 
-    /**
-     * @param $array
-     * @return mixed
-     */
-    private function convertToLuaTable( $array ) {
-        if ( is_array( $array ) ) {
-            foreach ( $array as $key => $value ) {
-                $array[$key] = $this->convertToLuaTable( $value );
-            }
+	/**
+	 * @param $array
+	 * @return mixed
+	 */
+	private function convertToLuaTable( $array ) {
+		if ( is_array( $array ) ) {
+			foreach ( $array as $key => $value ) {
+				$array[$key] = $this->convertToLuaTable( $value );
+			}
 
-            array_unshift( $array, '' );
-            unset( $array[0] );
-        }
+			array_unshift( $array, '' );
+			unset( $array[0] );
+		}
 
-        return $array;
-    }
+		return $array;
+	}
 }

--- a/src/WikiSearchHooks.php
+++ b/src/WikiSearchHooks.php
@@ -217,25 +217,25 @@ abstract class WikiSearchHooks {
 		$propertyInitializer->initProperties();
 	}
 
-    /**
-     * Allow extensions to add libraries to Scribunto.
-     *
-     * @link https://www.mediawiki.org/wiki/Extension:Scribunto/Hooks/ScribuntoExternalLibraries
-     *
-     * @param string $engine
-     * @param array $extraLibraries
-     * @return bool
-     */
-    public static function onScribuntoExternalLibraries( string $engine, array &$extraLibraries ): bool {
-        if ( $engine !== 'lua' ) {
-            // Don't mess with other engines
-            return true;
-        }
+	/**
+	 * Allow extensions to add libraries to Scribunto.
+	 *
+	 * @link https://www.mediawiki.org/wiki/Extension:Scribunto/Hooks/ScribuntoExternalLibraries
+	 *
+	 * @param string $engine
+	 * @param array &$extraLibraries
+	 * @return bool
+	 */
+	public static function onScribuntoExternalLibraries( string $engine, array &$extraLibraries ): bool {
+		if ( $engine !== 'lua' ) {
+			// Don't mess with other engines
+			return true;
+		}
 
-        $extraLibraries['wikisearch'] = ScribuntoLuaLibrary::class;
+		$extraLibraries['wikisearch'] = ScribuntoLuaLibrary::class;
 
-        return true;
-    }
+		return true;
+	}
 
 	/**
 	 * Hook to extend the SemanticData object before the update is completed.


### PR DESCRIPTION
This pull request adds a new filter that support fuzzy queries (see [ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-fuzzy-query.html)). It may be used as follows:

```
{
    "key": "Class",
    "value": "Manual",
    "type": "fuzzy",
    "fuzziness": 6 # Optional
}
```

This closes #25.