### PR TITLE
Add source filtering and allow annotators to be disabled

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -3,7 +3,7 @@
 	"author": [
 		"Marijn van Wezel"
 	],
-	"version": "6.5.0",
+	"version": "7.0.0",
 	"url": "https://www.mediawiki.org/wiki/Extension:WikiSearch",
 	"descriptionmsg": "wikisearch-desc",
 	"license-name": "GPL-2.0-or-later",
@@ -80,6 +80,9 @@
 		},
 		"WikiSearchEscape": {
 			"value": false
+		},
+		"WikiSearchDisabledAnnotators": {
+			"value": []
 		}
 	},
 	"SpecialPages": {

--- a/src/QueryEngine/Factory/QueryEngineFactory.php
+++ b/src/QueryEngine/Factory/QueryEngineFactory.php
@@ -38,13 +38,19 @@ class QueryEngineFactory {
 
 		foreach ( $config->getFacetProperties() as $facet_property ) {
 			$aggregation = new PropertyValueAggregation(
-				explode( "=", $facet_property )[0],
+				$facet_property,
 				null,
 				$aggregation_size
 			);
 
 			$query_engine->addAggregation( $aggregation );
 		}
+
+        foreach ( $config->getResultProperties() as $result_property ) {
+            // Include this property and any sub-properties in the result
+            $source = $result_property->getPropertyField() . ".*";
+
+        }
 
 		// Configure the base query
 		if ( $config->getSearchParameter( "base query" ) !== false ) {

--- a/src/QueryEngine/Factory/QueryEngineFactory.php
+++ b/src/QueryEngine/Factory/QueryEngineFactory.php
@@ -50,6 +50,7 @@ class QueryEngineFactory {
             // Include this property and any sub-properties in the result
             $source = $result_property->getPropertyField() . ".*";
 
+            $query_engine->addSource( $source );
         }
 
 		// Configure the base query

--- a/src/QueryEngine/Factory/QueryEngineFactory.php
+++ b/src/QueryEngine/Factory/QueryEngineFactory.php
@@ -46,12 +46,12 @@ class QueryEngineFactory {
 			$query_engine->addAggregation( $aggregation );
 		}
 
-        foreach ( $config->getResultProperties() as $result_property ) {
-            // Include this property and any sub-properties in the result
-            $source = $result_property->getPropertyField() . ".*";
+		foreach ( $config->getResultProperties() as $result_property ) {
+			// Include this property and any sub-properties in the result
+			$source = $result_property->getPID() . ".*";
 
-            $query_engine->addSource( $source );
-        }
+			$query_engine->addSource( $source );
+		}
 
 		// Configure the base query
 		if ( $config->getSearchParameter( "base query" ) !== false ) {

--- a/src/QueryEngine/QueryEngine.php
+++ b/src/QueryEngine/QueryEngine.php
@@ -85,6 +85,7 @@ class QueryEngine {
 	 */
 	private array $sources = [
 		'subject.*', // Subject metadata
+        'P:16.*', // Display title of
 		'P:29.*' // Modification date
 	];
 

--- a/src/QueryEngine/QueryEngine.php
+++ b/src/QueryEngine/QueryEngine.php
@@ -78,7 +78,14 @@ class QueryEngine {
 	 */
 	private array $post_filters = [];
 
-	/**
+    /**
+     * List of properties to include in the "_source" field.
+     *
+     * @var string
+     */
+    private string $sources;
+
+    /**
 	 * QueryEngine constructor.
 	 *
 	 * @param string $index The ElasticSearch index to create the queries for
@@ -166,6 +173,21 @@ class QueryEngine {
 		$this->elasticsearch_search->addSort( $sort->toQuery() );
 	}
 
+    /**
+     * Adds an item to the "_source" parameter. This allows users to specify explicitly which fields should
+     * be returned from a search query.
+     *
+     * If no "_source" parameters are set, all fields are returned.
+     *
+     * @param string $source
+     * @return void
+     *
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.5/search-request-source-filtering.html
+     */
+    public function addSource( string $source ): void {
+        $this->sources = $source;
+    }
+
 	/**
 	 * Sets the "index" to use for the ElasticSearch query.
 	 *
@@ -240,11 +262,18 @@ class QueryEngine {
 		Logger::getLogger()->debug( 'Constructing ElasticSearch query from QueryEngine' );
 
 		$elasticsearch_search = clone $this->elasticsearch_search;
+
+        // Add aggregations and post-filters to the query
 		$elasticsearch_search = $this->applyAggregationsAndPostFilters(
 			$elasticsearch_search,
 			$this->aggregations,
 			$this->post_filters
 		);
+
+        // Add source filtering to the query
+        if ( !empty( $this->sources ) ) {
+            $this->elasticsearch_search->setSource( $this->sources );
+        }
 
 		$query = [
 			"index" => $this->elasticsearch_index,
@@ -252,7 +281,9 @@ class QueryEngine {
 		];
 
 		if ( isset( $this->base_query ) ) {
-			$query = ( new QueryCombinator( $query ) )->add( $this->base_query )->getQuery();
+            // Combine any base query with the generated query
+            $combinator = new QueryCombinator( $query );
+			$query = $combinator->add( $this->base_query )->getQuery();
 		}
 
 		return $query;

--- a/src/QueryEngine/QueryEngine.php
+++ b/src/QueryEngine/QueryEngine.php
@@ -272,7 +272,7 @@ class QueryEngine {
 
 		// Add source filtering to the query
 		if ( !empty( $this->sources ) ) {
-			$this->elasticsearch_search->setSource( $this->sources );
+			$elasticsearch_search->setSource( $this->sources );
 		}
 
 		$query = [

--- a/src/QueryEngine/QueryEngine.php
+++ b/src/QueryEngine/QueryEngine.php
@@ -78,14 +78,14 @@ class QueryEngine {
 	 */
 	private array $post_filters = [];
 
-    /**
-     * List of properties to include in the "_source" field.
-     *
-     * @var array
-     */
-    private array $sources;
+	/**
+	 * List of properties to include in the "_source" field.
+	 *
+	 * @var array
+	 */
+	private array $sources;
 
-    /**
+	/**
 	 * QueryEngine constructor.
 	 *
 	 * @param string $index The ElasticSearch index to create the queries for
@@ -173,20 +173,20 @@ class QueryEngine {
 		$this->elasticsearch_search->addSort( $sort->toQuery() );
 	}
 
-    /**
-     * Adds an item to the "_source" parameter. This allows users to specify explicitly which fields should
-     * be returned from a search query.
-     *
-     * If no "_source" parameters are set, all fields are returned.
-     *
-     * @param string $source
-     * @return void
-     *
-     * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.5/search-request-source-filtering.html
-     */
-    public function addSource( string $source ): void {
-        $this->sources[] = $source;
-    }
+	/**
+	 * Adds an item to the "_source" parameter. This allows users to specify explicitly which fields should
+	 * be returned from a search query.
+	 *
+	 * If no "_source" parameters are set, all fields are returned.
+	 *
+	 * @param string $source
+	 * @return void
+	 *
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.5/search-request-source-filtering.html
+	 */
+	public function addSource( string $source ): void {
+		$this->sources[] = $source;
+	}
 
 	/**
 	 * Sets the "index" to use for the ElasticSearch query.
@@ -263,17 +263,17 @@ class QueryEngine {
 
 		$elasticsearch_search = clone $this->elasticsearch_search;
 
-        // Add aggregations and post-filters to the query
+		// Add aggregations and post-filters to the query
 		$elasticsearch_search = $this->applyAggregationsAndPostFilters(
 			$elasticsearch_search,
 			$this->aggregations,
 			$this->post_filters
 		);
 
-        // Add source filtering to the query
-        if ( !empty( $this->sources ) ) {
-            $this->elasticsearch_search->setSource( $this->sources );
-        }
+		// Add source filtering to the query
+		if ( !empty( $this->sources ) ) {
+			$this->elasticsearch_search->setSource( $this->sources );
+		}
 
 		$query = [
 			"index" => $this->elasticsearch_index,
@@ -281,8 +281,8 @@ class QueryEngine {
 		];
 
 		if ( isset( $this->base_query ) ) {
-            // Combine any base query with the generated query
-            $combinator = new QueryCombinator( $query );
+			// Combine any base query with the generated query
+			$combinator = new QueryCombinator( $query );
 			$query = $combinator->add( $this->base_query )->getQuery();
 		}
 

--- a/src/QueryEngine/QueryEngine.php
+++ b/src/QueryEngine/QueryEngine.php
@@ -83,7 +83,10 @@ class QueryEngine {
 	 *
 	 * @var array
 	 */
-	private array $sources;
+	private array $sources = [
+		'subject.*', // Subject metadata
+		'P:29.*' // Modification date
+	];
 
 	/**
 	 * QueryEngine constructor.
@@ -271,12 +274,7 @@ class QueryEngine {
 		);
 
 		// Add source filtering to the query
-		if ( !empty( $this->sources ) ) {
-			$elasticsearch_search->setSource( $this->sources );
-		} else {
-			// No sources should be returned
-			$elasticsearch_search->setSource( false );
-		}
+		$elasticsearch_search->setSource( $this->sources );
 
 		$query = [
 			"index" => $this->elasticsearch_index,

--- a/src/QueryEngine/QueryEngine.php
+++ b/src/QueryEngine/QueryEngine.php
@@ -81,9 +81,9 @@ class QueryEngine {
     /**
      * List of properties to include in the "_source" field.
      *
-     * @var string
+     * @var array
      */
-    private string $sources;
+    private array $sources;
 
     /**
 	 * QueryEngine constructor.
@@ -185,7 +185,7 @@ class QueryEngine {
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.5/search-request-source-filtering.html
      */
     public function addSource( string $source ): void {
-        $this->sources = $source;
+        $this->sources[] = $source;
     }
 
 	/**

--- a/src/QueryEngine/QueryEngine.php
+++ b/src/QueryEngine/QueryEngine.php
@@ -273,6 +273,9 @@ class QueryEngine {
 		// Add source filtering to the query
 		if ( !empty( $this->sources ) ) {
 			$elasticsearch_search->setSource( $this->sources );
+		} else {
+			// No sources should be returned
+			$elasticsearch_search->setSource( false );
 		}
 
 		$query = [

--- a/src/SMW/Annotators/Annotator.php
+++ b/src/SMW/Annotators/Annotator.php
@@ -7,7 +7,7 @@ use ParserOutput;
 use SMW\SemanticData;
 
 interface Annotator {
-    /**
+	/**
 	 * Analyze the given parser output and decorate the given semantic data object with the results.
 	 *
 	 * @param Content $content

--- a/src/SMW/Annotators/Annotator.php
+++ b/src/SMW/Annotators/Annotator.php
@@ -7,15 +7,7 @@ use ParserOutput;
 use SMW\SemanticData;
 
 interface Annotator {
-	public const ANNOTATORS = [
-		AltTextAnnotator::class,
-		ImagesAnnotator::class,
-		InternalLinksAnnotator::class,
-		ExternalLinksAnnotator::class,
-		ParsedTextAnnotator::class
-	];
-
-	/**
+    /**
 	 * Analyze the given parser output and decorate the given semantic data object with the results.
 	 *
 	 * @param Content $content

--- a/src/SMW/PropertyFieldMapper.php
+++ b/src/SMW/PropertyFieldMapper.php
@@ -180,6 +180,34 @@ class PropertyFieldMapper {
 	}
 
 	/**
+	 * Returns the type of this property.
+	 *
+	 * @return string
+	 * @deprecated Use getPropertyFieldType() instead
+	 */
+	public function getPropertyType(): string {
+		return sprintf( "%sField", $this->property_field_type );
+	}
+
+	/**
+	 * Returns the ID of the property.
+	 *
+	 * @return int
+	 */
+	public function getPropertyID(): int {
+		return $this->property_id;
+	}
+
+	/**
+	 * Returns the field type of this property.
+	 *
+	 * @return string
+	 */
+	public function getPropertyFieldType(): string {
+		return $this->property_field_type;
+	}
+
+	/**
 	 * Returns the field associated with this property.
 	 *
 	 * @return string

--- a/src/SMW/PropertyFieldMapper.php
+++ b/src/SMW/PropertyFieldMapper.php
@@ -153,34 +153,6 @@ class PropertyFieldMapper {
 	}
 
 	/**
-	 * Returns the type of this property.
-	 *
-	 * @return string
-	 * @deprecated Use getPropertyFieldType() instead
-	 */
-	public function getPropertyType(): string {
-		return sprintf( "%sField", $this->property_field_type );
-	}
-
-	/**
-	 * Returns the ID of the property.
-	 *
-	 * @return int
-	 */
-	public function getPropertyID(): int {
-		return $this->property_id;
-	}
-
-	/**
-	 * Returns the field type of this property.
-	 *
-	 * @return string
-	 */
-	public function getPropertyFieldType(): string {
-		return $this->property_field_type;
-	}
-
-	/**
 	 * Returns the key of this property.
 	 *
 	 * @return string
@@ -205,15 +177,6 @@ class PropertyFieldMapper {
 	 */
 	public function getPID(): string {
 		return "P:{$this->property_id}";
-	}
-
-	/**
-	 * Returns the weight this property was given.
-	 *
-	 * @return int
-	 */
-	public function getPropertyWeight(): int {
-		return $this->property_weight;
 	}
 
 	/**
@@ -258,16 +221,6 @@ class PropertyFieldMapper {
 	 */
 	public function getWeightedPropertyField(): string {
 		return sprintf( "%s^%d", $this->getPropertyField(), $this->property_weight );
-	}
-
-	/**
-	 * Returns the keyword subfield associated with this property, if it exists, with the weight. The caller is
-	 * responsible for checking if this field exists.
-	 *
-	 * @return string
-	 */
-	public function getWeightedKeywordField(): string {
-		return sprintf( "%s^%d", $this->getKeywordField(), $this->property_weight );
 	}
 
 	/**

--- a/src/SMW/PropertyFieldMapper.php
+++ b/src/SMW/PropertyFieldMapper.php
@@ -190,7 +190,7 @@ class PropertyFieldMapper {
 			return $this->property_key;
 		}
 
-		return sprintf( "%s.%sField", $this->getPID(), $this->getPropertyFieldType() );
+		return sprintf( "%s.%sField", $this->getPID(), $this->property_field_type );
 	}
 
 	/**

--- a/src/SMW/PropertyInitializer.php
+++ b/src/SMW/PropertyInitializer.php
@@ -2,13 +2,27 @@
 
 namespace WikiSearch\SMW;
 
+use MediaWiki\MediaWikiServices;
 use SMW\PropertyRegistry;
+use WikiSearch\SMW\Annotators\AltTextAnnotator;
 use WikiSearch\SMW\Annotators\Annotator;
+use WikiSearch\SMW\Annotators\ExternalLinksAnnotator;
+use WikiSearch\SMW\Annotators\ImagesAnnotator;
+use WikiSearch\SMW\Annotators\InternalLinksAnnotator;
+use WikiSearch\SMW\Annotators\ParsedTextAnnotator;
 
 /**
  * Initializes the predefined properties that may be used for search.
  */
 class PropertyInitializer {
+    public const ANNOTATORS = [
+        AltTextAnnotator::class,
+        ImagesAnnotator::class,
+        InternalLinksAnnotator::class,
+        ExternalLinksAnnotator::class,
+        ParsedTextAnnotator::class
+    ];
+
 	/**
 	 * @var PropertyRegistry The PropertyRegistry in which to initialise the predefined properties
 	 */
@@ -20,6 +34,20 @@ class PropertyInitializer {
 	public function __construct( PropertyRegistry $registry ) {
 		$this->registry = $registry;
 	}
+
+    /**
+     * Returns the array of enabled annotators. Annotators can be disabled by adding their ID to the
+     * $wgWikiSearchDisabledAnnotators array.
+     *
+     * @return array
+     */
+    public static function getAnnotators(): array {
+        $disabledAnnotators = MediaWikiServices::getInstance()->getMainConfig()->get( "WikiSearchDisabledAnnotators" );
+
+        return array_filter( self::ANNOTATORS, function ( $class ) use ( $disabledAnnotators ): bool {
+            return !in_array( $class::getId(), $disabledAnnotators, true );
+        } );
+    }
 
 	/**
 	 * Initialize the predefined properties.
@@ -67,9 +95,8 @@ class PropertyInitializer {
 	 */
 	public function getPropertyDefinitions(): array {
 		$definitions = [];
-		$annotators = Annotator::ANNOTATORS;
 
-		foreach ( $annotators as $annotation ) {
+		foreach ( self::getAnnotators() as $annotation ) {
 			$definitions[$annotation::getId()] = $annotation::getDefinition();
 		}
 

--- a/src/SMW/PropertyInitializer.php
+++ b/src/SMW/PropertyInitializer.php
@@ -5,7 +5,6 @@ namespace WikiSearch\SMW;
 use MediaWiki\MediaWikiServices;
 use SMW\PropertyRegistry;
 use WikiSearch\SMW\Annotators\AltTextAnnotator;
-use WikiSearch\SMW\Annotators\Annotator;
 use WikiSearch\SMW\Annotators\ExternalLinksAnnotator;
 use WikiSearch\SMW\Annotators\ImagesAnnotator;
 use WikiSearch\SMW\Annotators\InternalLinksAnnotator;
@@ -15,13 +14,13 @@ use WikiSearch\SMW\Annotators\ParsedTextAnnotator;
  * Initializes the predefined properties that may be used for search.
  */
 class PropertyInitializer {
-    public const ANNOTATORS = [
-        AltTextAnnotator::class,
-        ImagesAnnotator::class,
-        InternalLinksAnnotator::class,
-        ExternalLinksAnnotator::class,
-        ParsedTextAnnotator::class
-    ];
+	public const ANNOTATORS = [
+		AltTextAnnotator::class,
+		ImagesAnnotator::class,
+		InternalLinksAnnotator::class,
+		ExternalLinksAnnotator::class,
+		ParsedTextAnnotator::class
+	];
 
 	/**
 	 * @var PropertyRegistry The PropertyRegistry in which to initialise the predefined properties
@@ -35,19 +34,19 @@ class PropertyInitializer {
 		$this->registry = $registry;
 	}
 
-    /**
-     * Returns the array of enabled annotators. Annotators can be disabled by adding their ID to the
-     * $wgWikiSearchDisabledAnnotators array.
-     *
-     * @return array
-     */
-    public static function getAnnotators(): array {
-        $disabledAnnotators = MediaWikiServices::getInstance()->getMainConfig()->get( "WikiSearchDisabledAnnotators" );
+	/**
+	 * Returns the array of enabled annotators. Annotators can be disabled by adding their ID to the
+	 * $wgWikiSearchDisabledAnnotators array.
+	 *
+	 * @return array
+	 */
+	public static function getAnnotators(): array {
+		$disabledAnnotators = MediaWikiServices::getInstance()->getMainConfig()->get( "WikiSearchDisabledAnnotators" );
 
-        return array_filter( self::ANNOTATORS, function ( $class ) use ( $disabledAnnotators ): bool {
-            return !in_array( $class::getId(), $disabledAnnotators, true );
-        } );
-    }
+		return array_filter( self::ANNOTATORS, function ( $class ) use ( $disabledAnnotators ): bool {
+			return !in_array( $class::getId(), $disabledAnnotators, true );
+		} );
+	}
 
 	/**
 	 * Initialize the predefined properties.

--- a/src/Scribunto/ScribuntoLuaLibrary.php
+++ b/src/Scribunto/ScribuntoLuaLibrary.php
@@ -23,116 +23,112 @@ namespace WikiSearch\Scribunto;
 
 use Elasticsearch\ClientBuilder;
 use MWException;
-use TextContent;
-use WikibaseSolutions\MediaWikiTemplateParser\RecursiveParser;
 use WikiSearch\QueryEngine\Aggregation\FilterAggregation;
 use WikiSearch\QueryEngine\Aggregation\PropertyValueAggregation;
 use WikiSearch\QueryEngine\Factory\QueryEngineFactory;
 use WikiSearch\QueryEngine\Filter\PropertyRangeFilter;
-use WSSlots\WikiPageTrait;
-use WSSlots\WSSlots;
 
 /**
  * Register the Lua library.
  */
 class ScribuntoLuaLibrary extends \Scribunto_LuaLibraryBase {
-    /**
-     * @inheritDoc
-     */
-    public function register(): void {
-        $interfaceFuncs = [
-            'propValues' => [ $this, 'propValues' ]
-        ];
+	/**
+	 * @inheritDoc
+	 */
+	public function register(): void {
+		$interfaceFuncs = [
+			'propValues' => [ $this, 'propValues' ]
+		];
 
-        $this->getEngine()->registerInterface( __DIR__ . '/' . 'mw.wikisearch.lua', $interfaceFuncs, [] );
-    }
+		$this->getEngine()->registerInterface( __DIR__ . '/' . 'mw.wikisearch.lua', $interfaceFuncs, [] );
+	}
 
-    /**
-     * This mirrors the functionality of the #prop_values parser function and makes it available in Lua.
-     *
-     * @param array $properties
-     * @return array
-     * @throws MWException
-     */
-    public function propValues( array $properties ): array {
-        $limit = $properties["limit"] ?? 100;
-        $property = $properties["property"] ?? "";
-        $dateProperty = $properties["date property"] ?? "Modification date";
-        $from = $properties["from"] ?? 1;
-        $to = $properties["to"] ?? 5000;
-        $baseQuery = $properties["query"] ?? null;
+	/**
+	 * This mirrors the functionality of the #prop_values parser function and makes it available in Lua.
+	 *
+	 * @param array $properties
+	 * @return array
+	 * @throws MWException
+	 */
+	public function propValues( array $properties ): array {
+		$limit = $properties["limit"] ?? 100;
+		$property = $properties["property"] ?? "";
+		$dateProperty = $properties["date property"] ?? "Modification date";
+		$from = $properties["from"] ?? 1;
+		$to = $properties["to"] ?? 5000;
+		$baseQuery = $properties["query"] ?? null;
 
-        if ( !$property || !is_int( $limit ) || !is_int( $from ) || !is_int( $to ) ) {
-            return [ null ];
-        }
+		if ( !$property || !is_int( $limit ) || !is_int( $from ) || !is_int( $to ) ) {
+			return [ null ];
+		}
 
-        if (
-            $from < 0 || $from > 9999 || // From range check
-            $to < 0 || $to > 9999 || // To range check
-            $to <= $from || // To-from order check
-            $limit < 1 || $limit > 9999 // Limit range check
-        ) {
-            return [ null ];
-        }
+		if (
+			$from < 0 || $from > 9999 || // From range check
+			$to < 0 || $to > 9999 || // To range check
+			$to <= $from || // To-from order check
+			$limit < 1 || $limit > 9999 // Limit range check
+		) {
+			return [ null ];
+		}
 
-        list( $from, $to ) = $this->convertDates( $from, $to );
+		list( $from, $to ) = $this->convertDates( $from, $to );
 
-        $rangeFilter = new PropertyRangeFilter( $dateProperty, [ "to" => $to, "from" => $from ] );
-        $termsAggregation = new PropertyValueAggregation( $property, "common_values", $limit );
-        $aggregation = new FilterAggregation( $rangeFilter, [ $termsAggregation ], "property_values" );
+		$rangeFilter = new PropertyRangeFilter( $dateProperty, [ "to" => $to, "from" => $from ] );
+		$termsAggregation = new PropertyValueAggregation( $property, "common_values", $limit );
+		$aggregation = new FilterAggregation( $rangeFilter, [ $termsAggregation ], "property_values" );
 
-        $queryEngine = QueryEngineFactory::fromNull();
-        $queryEngine->addAggregation( $aggregation );
+		$queryEngine = QueryEngineFactory::fromNull();
+		$queryEngine->addAggregation( $aggregation );
 
-        if ( isset( $baseQuery ) ) {
-            $queryEngine->setBaseQuery( $baseQuery );
-        }
+		if ( isset( $baseQuery ) ) {
+			$queryEngine->setBaseQuery( $baseQuery );
+		}
 
-        $results = ClientBuilder::create()
-            ->setHosts( QueryEngineFactory::fromNull()->getElasticHosts() )
-            ->build()
-            ->search( $queryEngine->toArray() );
+		$results = ClientBuilder::create()
+			->setHosts( QueryEngineFactory::fromNull()->getElasticHosts() )
+			->build()
+			->search( $queryEngine->toArray() );
 
-        if ( !isset( $results["aggregations"]["property_values"]["property_values"]["common_values"]["buckets"] ) ) {
-            // Failed to create aggregations
-            return [ null ];
-        }
+		if ( !isset( $results["aggregations"]["property_values"]["property_values"]["common_values"]["buckets"] ) ) {
+			// Failed to create aggregations
+			return [ null ];
+		}
 
-        $buckets = $results["aggregations"]["property_values"]["property_values"]["common_values"]["buckets"];
+		$buckets = $results["aggregations"]["property_values"]["property_values"]["common_values"]["buckets"];
 
-        if ( !is_array( $buckets ) ) {
-            // The aggregations are not valid
-            return [ null ];
-        }
+		if ( !is_array( $buckets ) ) {
+			// The aggregations are not valid
+			return [ null ];
+		}
 
-        return [ $this->convertToLuaTable( $buckets ) ];
-    }
+		return [ $this->convertToLuaTable( $buckets ) ];
+	}
 
-    /**
-     * Converts the given dates to Julian dates.
-     *
-     * @param int $from_year
-     * @param int $to_year
-     * @return array
-     */
-    private function convertDates( int $from_year, int $to_year ): array {
-        return [ gregoriantojd( 1, 1, $from_year ), gregoriantojd( 12, 31, $to_year ) ];
-    }
+	/**
+	 * Converts the given dates to Julian dates.
+	 *
+	 * @param int $from_year
+	 * @param int $to_year
+	 * @return array
+	 */
+	private function convertDates( int $from_year, int $to_year ): array {
+		return [ gregoriantojd( 1, 1, $from_year ), gregoriantojd( 12, 31, $to_year ) ];
+	}
 
-    /**
-     * @param $array
-     * @return mixed
-     */
-    private function convertToLuaTable( $array ) {
-        if ( is_array( $array ) ) {
-            foreach ( $array as $key => $value ) {
-                $array[$key] = $this->convertToLuaTable( $value );
-            }
+	/**
+	 * @param $array
+	 * @return mixed
+	 */
+	private function convertToLuaTable( $array ) {
+		if ( is_array( $array ) ) {
+			foreach ( $array as $key => $value ) {
+				$array[$key] = $this->convertToLuaTable( $value );
+			}
 
-            array_unshift( $array, '' );
-            unset( $array[0] );
-        }
+			array_unshift( $array, '' );
+			unset( $array[0] );
+		}
 
-        return $array;
-    }
+		return $array;
+	}
 }

--- a/src/SearchEngine.php
+++ b/src/SearchEngine.php
@@ -38,12 +38,7 @@ class SearchEngine {
 	/**
 	 * @var SearchEngineConfig
 	 */
-	private ?SearchEngineConfig $config = null;
-
-	/**
-	 * @var array
-	 */
-	private array $translations;
+	private SearchEngineConfig $config;
 
 	/**
 	 * @var QueryEngine
@@ -53,11 +48,10 @@ class SearchEngine {
 	/**
 	 * Search constructor.
 	 *
-	 * @param SearchEngineConfig|null $config
+	 * @param SearchEngineConfig $config
 	 */
 	public function __construct( SearchEngineConfig $config ) {
 		$this->config = $config;
-		$this->translations = $config->getPropertyTranslations();
 		$this->query_engine = QueryEngineFactory::fromSearchEngineConfig( $config );
 	}
 
@@ -164,12 +158,14 @@ class SearchEngine {
 		$aggregations = $results["aggregations"];
 
 		foreach ( $aggregations as $property_name => $aggregate_data ) {
-			if ( !isset( $this->translations[$property_name] ) ) {
+            $translations = $this->config->getPropertyTranslations();
+
+			if ( !isset( $translations[$property_name] ) ) {
 				// No translation available
 				continue;
 			}
 
-			$parts = explode( ":", $this->translations[$property_name] );
+			$parts = explode( ":", $translations[$property_name] );
 
 			if ( $parts[0] === "namespace" ) {
 				foreach ( $results['aggregations'][$property_name]['buckets'] as $bucket_key => $bucket_value ) {

--- a/src/SearchEngine.php
+++ b/src/SearchEngine.php
@@ -158,7 +158,7 @@ class SearchEngine {
 		$aggregations = $results["aggregations"];
 
 		foreach ( $aggregations as $property_name => $aggregate_data ) {
-            $translations = $this->config->getPropertyTranslations();
+			$translations = $this->config->getPropertyTranslations();
 
 			if ( !isset( $translations[$property_name] ) ) {
 				// No translation available

--- a/src/SearchEngineConfig.php
+++ b/src/SearchEngineConfig.php
@@ -202,7 +202,7 @@ class SearchEngineConfig {
 			$translation_pair = explode( "=", $property );
 			$property_name = $translation_pair[0];
 
-            $this->facet_properties[] = new PropertyFieldMapper( $property_name );
+			$this->facet_properties[] = new PropertyFieldMapper( $property_name );
 
 			if ( isset( $translation_pair[1] ) ) {
 				$this->translations[$property_name] = $translation_pair[1];
@@ -353,8 +353,8 @@ class SearchEngineConfig {
 		$page_id = $this->title->getArticleID();
 
 		$facet_properties = array_unique( array_map( function ( PropertyFieldMapper $property ): string {
-            return $property->getPropertyKey();
-        }, $this->facet_properties ) );
+			return $property->getPropertyKey();
+		}, $this->facet_properties ) );
 
 		$result_properties = array_unique( array_map( function ( PropertyFieldMapper $property ): string {
 			return $property->getPropertyKey();

--- a/src/SearchEngineConfig.php
+++ b/src/SearchEngineConfig.php
@@ -54,24 +54,14 @@ class SearchEngineConfig {
 	private array $search_parameters;
 
 	/**
-	 * @var array
+	 * @var PropertyFieldMapper[]
 	 */
 	private array $facet_properties;
 
 	/**
-	 * @var array
+	 * @var PropertyFieldMapper[]
 	 */
 	private array $result_properties;
-
-	/**
-	 * @var array
-	 */
-	private array $facet_property_ids = [];
-
-	/**
-	 * @var array
-	 */
-	private array $result_property_ids = [];
 
 	/**
 	 * @var array
@@ -198,7 +188,6 @@ class SearchEngineConfig {
 		array $result_properties
 	) {
 		$this->title = $title;
-		$this->facet_properties = $facet_properties;
 		$this->search_parameters = $search_parameters;
 
 		$result_properties = array_filter( $result_properties, function ( string $property_name ) {
@@ -213,16 +202,11 @@ class SearchEngineConfig {
 			$translation_pair = explode( "=", $property );
 			$property_name = $translation_pair[0];
 
+            $this->facet_properties[] = new PropertyFieldMapper( $property_name );
+
 			if ( isset( $translation_pair[1] ) ) {
 				$this->translations[$property_name] = $translation_pair[1];
 			}
-
-			$facet_property = new PropertyFieldMapper( $property_name );
-			$this->facet_property_ids[$property_name] = $facet_property->getPropertyID();
-		}
-
-		foreach ( $this->result_properties as $property ) {
-			$this->result_property_ids[$property->getPropertyName()] = $property->getPropertyID();
 		}
 
 		if ( isset( $search_parameters["base query"] ) ) {
@@ -321,24 +305,10 @@ class SearchEngineConfig {
 	 * Returns the facet properties (properties that are not prefixed with "?"). This may be
 	 * the name of the facet property (e.g. "Foobar") or a translation pair (e.g. "Foobar=Boofar").
 	 *
-	 * @return string[]
+	 * @return PropertyFieldMapper[]
 	 */
 	public function getFacetProperties(): array {
 		return $this->facet_properties;
-	}
-
-	/**
-	 * Returns key-value pairs of the property ID with the corresponding property type:
-	 *
-	 * [
-	 *      745 => "txtField",
-	 *      752 => "txtField"
-	 * ]
-	 *
-	 * @return array
-	 */
-	public function getFacetPropertyIDs(): array {
-		return $this->facet_property_ids;
 	}
 
 	/**
@@ -346,19 +316,10 @@ class SearchEngineConfig {
 	 * is the property from which the value will be used as the page link. Result properties
 	 * are the properties prefixed with a "?".
 	 *
-	 * @return \WikiSearch\SMW\PropertyFieldMapper[]
+	 * @return PropertyFieldMapper[]
 	 */
 	public function getResultProperties(): array {
 		return $this->result_properties;
-	}
-
-	/**
-	 * Returns the IDs for the result properties.
-	 *
-	 * @return int[]
-	 */
-	public function getResultPropertyIDs(): array {
-		return $this->result_property_ids;
 	}
 
 	/**
@@ -391,11 +352,13 @@ class SearchEngineConfig {
 	public function insert( DBConnRef $database ): void {
 		$page_id = $this->title->getArticleID();
 
-		$facet_properties = array_unique( $this->facet_properties );
-		$result_properties = array_map( function ( PropertyFieldMapper $property ): string {
+		$facet_properties = array_unique( array_map( function ( PropertyFieldMapper $property ): string {
+            return $property->getPropertyKey();
+        }, $this->facet_properties ) );
+
+		$result_properties = array_unique( array_map( function ( PropertyFieldMapper $property ): string {
 			return $property->getPropertyKey();
-		}, $this->result_properties );
-		$result_properties = array_unique( $result_properties );
+		}, $this->result_properties ) );
 
 		// Insert this object's facet properties
 		foreach ( $facet_properties as $property ) {

--- a/src/SearchEngineConfig.php
+++ b/src/SearchEngineConfig.php
@@ -353,11 +353,14 @@ class SearchEngineConfig {
 		$page_id = $this->title->getArticleID();
 
 		$facet_properties = array_unique( array_map( function ( PropertyFieldMapper $property ): string {
-			return $property->getPropertyKey();
+            // Use 'getPropertyName' here to make sure that the value in the database corresponds directly to the
+            // value present in the parser function call (otherwise it might be translated to something else, causing
+            // several problems in the front-end)
+			return $property->getPropertyName();
 		}, $this->facet_properties ) );
 
 		$result_properties = array_unique( array_map( function ( PropertyFieldMapper $property ): string {
-			return $property->getPropertyKey();
+			return $property->getPropertyName();
 		}, $this->result_properties ) );
 
 		// Insert this object's facet properties

--- a/src/WikiSearchHooks.php
+++ b/src/WikiSearchHooks.php
@@ -39,7 +39,6 @@ use Title;
 use User;
 use WikiPage;
 use WikiSearch\Scribunto\ScribuntoLuaLibrary;
-use WikiSearch\SMW\Annotators\Annotator;
 use WikiSearch\SMW\PropertyInitializer;
 
 /**
@@ -217,25 +216,25 @@ abstract class WikiSearchHooks {
 		$propertyInitializer->initProperties();
 	}
 
-    /**
-     * Allow extensions to add libraries to Scribunto.
-     *
-     * @link https://www.mediawiki.org/wiki/Extension:Scribunto/Hooks/ScribuntoExternalLibraries
-     *
-     * @param string $engine
-     * @param array $extraLibraries
-     * @return bool
-     */
-    public static function onScribuntoExternalLibraries( string $engine, array &$extraLibraries ): bool {
-        if ( $engine !== 'lua' ) {
-            // Don't mess with other engines
-            return true;
-        }
+	/**
+	 * Allow extensions to add libraries to Scribunto.
+	 *
+	 * @link https://www.mediawiki.org/wiki/Extension:Scribunto/Hooks/ScribuntoExternalLibraries
+	 *
+	 * @param string $engine
+	 * @param array &$extraLibraries
+	 * @return bool
+	 */
+	public static function onScribuntoExternalLibraries( string $engine, array &$extraLibraries ): bool {
+		if ( $engine !== 'lua' ) {
+			// Don't mess with other engines
+			return true;
+		}
 
-        $extraLibraries['wikisearch'] = ScribuntoLuaLibrary::class;
+		$extraLibraries['wikisearch'] = ScribuntoLuaLibrary::class;
 
-        return true;
-    }
+		return true;
+	}
 
 	/**
 	 * Hook to extend the SemanticData object before the update is completed.

--- a/src/WikiSearchHooks.php
+++ b/src/WikiSearchHooks.php
@@ -267,7 +267,7 @@ abstract class WikiSearchHooks {
 
 		$output = $content->getParserOutput( $subjectTitle );
 
-		foreach ( Annotator::ANNOTATORS as $annotator ) {
+		foreach ( PropertyInitializer::getAnnotators() as $annotator ) {
 			// Decorate the semantic data object with the annotation
 			$annotator::addAnnotation( $content, $output, $semanticData );
 		}


### PR DESCRIPTION
This pull request:

* Adds source filtering;
* Allows annotators to be disabled.

### Source filtering

Source filtering allows the user to specify which fields to include in the search result. This can be done by adding the name of the field prefixed with a `?` to the `WikiSearchConfig` parser function.

This is a breaking change, since fields now have to be explicitly listed before they are returned and can be displayed in the front-end. Before this change, all fields were returned, which added unnecessary data overhead.

N.B. This feature was mistakenly already included in the documentation.

### Allow annotators to be disabled

Annotators can now optionally be disabled through the `$wgWikiSearchDisabledAnnotators` configuration parameter. This parameter takes a list of annotator IDs to disable. By default, all annotators are *enabled*.

The IDs of the annotators are as follows:

* Image alt texts: `__wikisearch_image_alt_texts`
* External links: `__wikisearch_external_links`
* Image links: `__wikisearch_image_links`
* Internal links: `__wikisearch_internal_links`
* Parsed text: `__wikisearch_parsed_text`