### PR TITLE
Only set the API to read mode when `read` is a required right

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -67,7 +67,8 @@
 			"value": [
 				"read",
 				"wikisearch-execute-api"
-			]
+			],
+			"_merge_strategy": "provide_default"
 		},
 		"WikiSearchSearchFieldOverride": {
 			"value": false

--- a/extension.json
+++ b/extension.json
@@ -3,7 +3,7 @@
 	"author": [
 		"Marijn van Wezel"
 	],
-	"version": "7.0.1",
+	"version": "7.0.2",
 	"url": "https://www.mediawiki.org/wiki/Extension:WikiSearch",
 	"descriptionmsg": "wikisearch-desc",
 	"license-name": "GPL-2.0-or-later",

--- a/extension.json
+++ b/extension.json
@@ -68,7 +68,7 @@
 				"read",
 				"wikisearch-execute-api"
 			],
-			"_merge_strategy": "provide_default"
+			"merge_strategy": "provide_default"
 		},
 		"WikiSearchSearchFieldOverride": {
 			"value": false

--- a/src/API/ApiQueryWikiSearchBase.php
+++ b/src/API/ApiQueryWikiSearchBase.php
@@ -33,15 +33,20 @@ use WikiSearch\Logger;
  */
 abstract class ApiQueryWikiSearchBase extends ApiQueryBase {
 	/**
+	 * @inheritDoc
+	 */
+	public function isReadMode() {
+		return in_array( 'read', $this->getConfig()->get( "WikiSearchAPIRequiredRights" ), true );
+	}
+
+	/**
 	 * Checks applicable user rights.
 	 *
 	 * @throws ApiUsageException
 	 */
 	protected function checkUserRights(): void {
-		$config = MediaWikiServices::getInstance()->getMainConfig();
-
 		try {
-			$required_rights = $config->get( "WikiSearchAPIRequiredRights" );
+			$required_rights = $this->getConfig()->get( "WikiSearchAPIRequiredRights" );
 			$this->checkUserRightsAny( $required_rights );
 		} catch ( \ConfigException $e ) {
 			Logger::getLogger()->critical(


### PR DESCRIPTION
This pull request, when merged:
- Changes the merge strategy for "WikiSearchAPIRequiredRights" to "provide_default", so that it is possible to remove default required rights;
- Only sets the API to read mode when "read" is a required right.

TODO: We need to add to the documentation that if you remove `read` as a required right, you must be careful to only give very strict base queries as to not leak possibly confidential information.