### PR TITLE
Make compatible with 1.39 and a number of other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,37 @@ The above filter executes the given query and only includes pages that matched t
 
 See also: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html
 
+#### PropertyFuzzyValueFilter
+
+This filter only returns pages that have the specified property with approximately the specified value.
+
+```
+{
+    "key": "Class",
+    "value": "Manual",
+    "type": "fuzzy"
+}
+```
+
+The above filter only includes pages where the property `Class` has a value similar to `Manual`. The `value` must be
+a string.
+
+Additionally, the maximum edit distance can be specified through the `fuzziness` parameter:
+
+```
+{
+    "key": "Class",
+    "value": "Manual",
+    "type": "fuzzy",
+    "fuzziness": 6
+}
+```
+
+`fuzziness` must either be the string "AUTO" to automatically determine the appropriate fuzziness (default), or
+a positive integer specifying the maximum edit distance.
+
+See also: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-fuzzy-query.html
+
 ### Aggregations syntax
 
 The `aggregations` parameter takes a list of objects. These objects have the following form:

--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,14 @@
     "name": "open-csp/wiki-search",
     "type": "mediawiki-extension",
     "description": "Faceted search for Semantic MediaWiki",
-    "keywords": ["mediawiki", "search", "extension"],
+    "keywords": [
+        "mediawiki",
+        "search",
+        "extension"
+    ],
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": "^7.4",
+        "php": ">= 7.4 < 8.3",
         "elasticsearch/elasticsearch": "^5.3|^6.0",
         "ongr/elasticsearch-dsl": "~6.0",
         "composer/installers": "1.*,>=1.0.1",
@@ -27,5 +31,10 @@
             "minus-x fix .",
             "phpcbf"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true
+        }
     }
 }

--- a/extension.json
+++ b/extension.json
@@ -3,7 +3,7 @@
 	"author": [
 		"Marijn van Wezel"
 	],
-	"version": "7.0.2",
+	"version": "8.0.0",
 	"url": "https://www.mediawiki.org/wiki/Extension:WikiSearch",
 	"descriptionmsg": "wikisearch-desc",
 	"license-name": "GPL-2.0-or-later",

--- a/extension.json
+++ b/extension.json
@@ -67,7 +67,8 @@
 			"value": [
 				"read",
 				"wikisearch-execute-api"
-			]
+			],
+			"merge_strategy": "provide_default"
 		},
 		"WikiSearchSearchFieldOverride": {
 			"value": false

--- a/extension.json
+++ b/extension.json
@@ -3,7 +3,7 @@
 	"author": [
 		"Marijn van Wezel"
 	],
-	"version": "8.0.0",
+	"version": "7.0.2",
 	"url": "https://www.mediawiki.org/wiki/Extension:WikiSearch",
 	"descriptionmsg": "wikisearch-desc",
 	"license-name": "GPL-2.0-or-later",

--- a/src/API/ApiQueryWikiSearchBase.php
+++ b/src/API/ApiQueryWikiSearchBase.php
@@ -33,15 +33,20 @@ use WikiSearch\Logger;
  */
 abstract class ApiQueryWikiSearchBase extends ApiQueryBase {
 	/**
+	 * @inheritDoc
+	 */
+	public function isReadMode() {
+		return in_array( 'read', $this->getConfig()->get( "WikiSearchAPIRequiredRights" ), true );
+	}
+
+	/**
 	 * Checks applicable user rights.
 	 *
 	 * @throws ApiUsageException
 	 */
 	protected function checkUserRights(): void {
-		$config = MediaWikiServices::getInstance()->getMainConfig();
-
 		try {
-			$required_rights = $config->get( "WikiSearchAPIRequiredRights" );
+			$required_rights = $this->getConfig()->get( "WikiSearchAPIRequiredRights" );
 			$this->checkUserRightsAny( $required_rights );
 		} catch ( \ConfigException $e ) {
 			Logger::getLogger()->critical(

--- a/src/PropertyValuesParserFunction.php
+++ b/src/PropertyValuesParserFunction.php
@@ -97,7 +97,9 @@ class PropertyValuesParserFunction {
 			return "";
 		}
 
-		\WSArrays::$arrays[$arrayName] = new \ComplexArray( $buckets );
+		if ( class_exists( "\ComplexArray" ) ) {
+			\WSArrays::$arrays[$arrayName] = new \ComplexArray( $buckets );
+		}
 
 		return "";
 	}

--- a/src/QueryEngine/Factory/QueryEngineFactory.php
+++ b/src/QueryEngine/Factory/QueryEngineFactory.php
@@ -3,12 +3,13 @@
 namespace WikiSearch\QueryEngine\Factory;
 
 use MediaWiki\MediaWikiServices;
+// Note: MW 1.40+ will have MediaWiki\WikiMap\WikiMap instead
+use WikiMap;
 use WikiSearch\Logger;
 use WikiSearch\QueryEngine\Aggregation\PropertyValueAggregation;
 use WikiSearch\QueryEngine\Highlighter\DefaultHighlighter;
 use WikiSearch\QueryEngine\QueryEngine;
 use WikiSearch\SearchEngineConfig;
-use WikiMap; // Note: MW 1.40+ will have MediaWiki\WikiMap\WikiMap instead
 
 class QueryEngineFactory {
 	/**

--- a/src/QueryEngine/Factory/SortFactory.php
+++ b/src/QueryEngine/Factory/SortFactory.php
@@ -20,12 +20,11 @@ class SortFactory {
 	 * @param array $array
 	 * @return Sort|null
 	 */
-	public static function fromArray( array $array ): Sort {
+	public static function fromArray( array $array ): ?Sort {
 		Logger::getLogger()->debug( 'Constructing Sort from array' );
 
 		if ( !isset( $array["type"] ) ) {
 			Logger::getLogger()->debug( 'Failed to construct Sort from array: missing "type"' );
-
 			return null;
 		}
 
@@ -34,7 +33,6 @@ class SortFactory {
 				return self::propertySortFromArray( $array );
 			default:
 				Logger::getLogger()->debug( 'Failed to construct Sort from array: invalid "type"' );
-
 				return null;
 		}
 	}
@@ -45,10 +43,9 @@ class SortFactory {
 	 * @param array $array
 	 * @return PropertySort|null
 	 */
-	private static function propertySortFromArray( array $array ): PropertySort {
+	private static function propertySortFromArray( array $array ): ?PropertySort {
 		if ( !isset( $array["property"] ) ) {
 			Logger::getLogger()->debug( 'Failed to construct PropertySort from array: missing "property"' );
-
 			return null;
 		}
 
@@ -56,12 +53,9 @@ class SortFactory {
 
 		if ( !is_string( $property ) && !( $property instanceof PropertyFieldMapper ) ) {
 			Logger::getLogger()->debug( 'Failed to construct PropertySort from array: invalid "property"' );
-
 			return null;
 		}
 
-		$order = isset( $array["order"] ) ? $array["order"] : null;
-
-		return new PropertySort( $property, $order );
+		return new PropertySort( $property, $array["order"] ?? null );
 	}
 }

--- a/src/QueryEngine/Filter/PropertyFuzzyValueFilter.php
+++ b/src/QueryEngine/Filter/PropertyFuzzyValueFilter.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace WikiSearch\QueryEngine\Filter;
+
+use InvalidArgumentException;
+use ONGR\ElasticsearchDSL\Query\Compound\BoolQuery;
+use ONGR\ElasticsearchDSL\Query\TermLevel\FuzzyQuery;
+use WikiSearch\Logger;
+use WikiSearch\SMW\PropertyFieldMapper;
+
+/**
+ * Class PropertyFuzzyValueFilter
+ *
+ * Filters pages based on the values of their properties using fuzzy matching. This filter does not take
+ * property chains into account.
+ *
+ * @see ChainedPropertyFilter for a filter that takes property chains into account
+ *
+ * @package WikiSearch\QueryEngine\Filter
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-fuzzy-query.html
+ */
+class PropertyFuzzyValueFilter extends PropertyFilter {
+	/**
+	 * @var PropertyFieldMapper The property to filter on
+	 */
+	private PropertyFieldMapper $property;
+
+	/**
+	 * @var string|int The fuzziness to use, or "AUTO"
+	 */
+	private $fuzziness;
+
+	/**
+	 * @var mixed The value the property to filter on
+	 */
+	private $property_value;
+
+	/**
+	 * PropertyFuzzyValueFilter constructor.
+	 *
+	 * @param PropertyFieldMapper|string $property The name or object of the property to filter on
+	 * @param string $property_value The value the property to filter on
+	 * @param string|int $fuzziness The fuzziness to use, or "AUTO"
+	 */
+	public function __construct( $property, string $property_value, $fuzziness = "AUTO" ) {
+		if ( is_string( $property ) ) {
+			$property = new PropertyFieldMapper( $property );
+		}
+
+		if ( !( $property instanceof PropertyFieldMapper ) ) {
+			Logger::getLogger()->critical(
+				'Tried to construct a PropertyFuzzyValueFilter with an invalid property: {property}',
+				[
+					'property' => $property
+				]
+			);
+
+			throw new InvalidArgumentException( '$property must be of type string or PropertyFieldMapper' );
+		}
+
+		if ( $fuzziness !== "AUTO" && ( !is_int( $fuzziness ) || $fuzziness < 0 ) ) {
+			Logger::getLogger()->critical(
+				'Tried to construct a PropertyFuzzyValueFilter with an invalid fuzziness parameter: {fuzziness}',
+				[
+					'fuzziness' => $fuzziness
+				]
+			);
+
+			throw new InvalidArgumentException(
+				'$fuzziness must be "AUTO" or a positive integer'
+			);
+		}
+
+		$this->property = $property;
+		$this->property_value = $property_value;
+		$this->fuzziness = $fuzziness;
+	}
+
+	/**
+	 * Returns the property field mapper corresponding to this filter.
+	 *
+	 * @return PropertyFieldMapper
+	 */
+	public function getProperty(): PropertyFieldMapper {
+		return $this->property;
+	}
+
+	/**
+	 * Sets the property this filter will filter on.
+	 *
+	 * @param PropertyFieldMapper $property
+	 */
+	public function setPropertyName( PropertyFieldMapper $property ): void {
+		$this->property = $property;
+	}
+
+	/**
+	 * Sets the value of the property this filter will filter on.
+	 *
+	 * @param string $property_value
+	 */
+	public function setPropertyValue( string $property_value ): void {
+		$this->property_value = $property_value;
+	}
+
+	/**
+	 * Sets the value of the fuzziness parameter this filter will use.
+	 *
+	 * @param string|int $fuzziness The fuzziness to use, or "AUTO"
+	 * @return void
+	 */
+	public function setFuzziness( $fuzziness ): void {
+		if ( $fuzziness !== "AUTO" && ( !is_int( $fuzziness ) || $fuzziness < 0 ) ) {
+			Logger::getLogger()->critical(
+				'Tried to set an invalid value for fuzziness: {fuzziness}',
+				[
+					'fuzziness' => $fuzziness
+				]
+			);
+
+			throw new InvalidArgumentException(
+				'$fuzziness must be "AUTO" or a positive integer'
+			);
+		}
+	}
+
+	/**
+	 * Converts the object to a BuilderInterface for use in the QueryEngine.
+	 *
+	 * @return BoolQuery
+	 */
+	public function filterToQuery(): BoolQuery {
+		$field = $this->property->hasKeywordSubfield() ?
+			$this->property->getKeywordField() :
+			$this->property->getPropertyField();
+
+		$parameters = [
+			"fuzziness" => $this->fuzziness
+		];
+
+		$fuzzy_query = new FuzzyQuery( $field, $this->property_value, $parameters );
+
+		$bool_query = new BoolQuery();
+		$bool_query->add( $fuzzy_query, BoolQuery::FILTER );
+
+		/*
+		 * Example of such a query:
+		 *
+		 *  "bool": {
+		 *      "filter": {
+		 *          "fuzzy": {
+		 *              "P:0.wpgID": 0
+		 *          }
+		 *      }
+		 *  }
+		 */
+
+		return $bool_query;
+	}
+}

--- a/src/QueryEngine/Highlighter/FragmentHighlighter.php
+++ b/src/QueryEngine/Highlighter/FragmentHighlighter.php
@@ -49,22 +49,16 @@ class FragmentHighlighter implements Highlighter {
 	 * @param PropertyFieldMapper[] $properties The fields to apply the highlight to
 	 * @param int|null $size The fragment size
 	 * @param int $limit The maximum number of words to return
-	 * @param string $tag_left The left highlight tag
-	 * @param string $tag_right The right highlight tag
 	 */
 	public function __construct(
 		array $properties,
 		?string $highlighter_type = null,
 		int $size = 1,
-		int $limit = 128,
-		string $tag_left = "HIGHLIGHT_@@",
-		string $tag_right = "@@_HIGHLIGHT"
+		int $limit = 128
 	) {
 		$this->highlighter_type = $highlighter_type;
 		$this->size = $size;
 		$this->limit = $limit;
-		$this->tag_left = $tag_left;
-		$this->tag_right = $tag_right;
 		$this->fields = $properties;
 	}
 

--- a/src/QueryEngine/QueryEngine.php
+++ b/src/QueryEngine/QueryEngine.php
@@ -85,7 +85,7 @@ class QueryEngine {
 	 */
 	private array $sources = [
 		'subject.*', // Subject metadata
-        'P:16.*', // Display title of
+		'P:16.*', // Display title of
 		'P:29.*' // Modification date
 	];
 

--- a/src/SMW/PropertyFieldMapper.php
+++ b/src/SMW/PropertyFieldMapper.php
@@ -22,7 +22,6 @@
 namespace WikiSearch\SMW;
 
 use BadMethodCallException;
-use SMW\ApplicationFactory;
 use SMW\DataTypeRegistry;
 use SMW\DIProperty;
 use SMW\Elastic\ElasticStore;
@@ -119,7 +118,11 @@ class PropertyFieldMapper {
 	 * @param string $property_name The name of the property (chained property name allowed)
 	 */
 	public function __construct( string $property_name ) {
-		$store = ApplicationFactory::getInstance()->getStore();
+		if ( class_exists( '\SMW\StoreFactory' ) ) {
+			$store = \SMW\StoreFactory::getStore();
+		} else {
+			$store = \SMW\ApplicationFactory::getInstance()->getStore();
+		}
 
 		if ( !$store instanceof ElasticStore ) {
 			Logger::getLogger()->critical(

--- a/src/SMW/SMWQueryProcessor.php
+++ b/src/SMW/SMWQueryProcessor.php
@@ -57,8 +57,13 @@ class SMWQueryProcessor {
 
 		Logger::getLogger()->debug( 'Constructing QueryEngine from ElasticFactory' );
 
+		if ( class_exists( '\SMW\StoreFactory' ) ) {
+			$store = \SMW\StoreFactory::getStore();
+		} else {
+			$store = \SMW\ApplicationFactory::getInstance()->getStore();
+		}
+
 		$elastic_factory = new ElasticFactory();
-		$store = \SMW\ApplicationFactory::getInstance()->getStore();
 		$query_engine = $elastic_factory->newQueryEngine( $store );
 
 		Logger::getLogger()->debug( 'Finished constructing QueryEngine from ElasticFactory' );

--- a/src/SMW/WikiPageObjectIdLookup.php
+++ b/src/SMW/WikiPageObjectIdLookup.php
@@ -2,7 +2,6 @@
 
 namespace WikiSearch\SMW;
 
-use SMW\ApplicationFactory;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use Title;
@@ -22,7 +21,12 @@ class WikiPageObjectIdLookup {
 		] );
 
 		/** @var Store $store */
-		$store = ApplicationFactory::getInstance()->getStore();
+		if ( class_exists( '\SMW\StoreFactory' ) ) {
+			$store = \SMW\StoreFactory::getStore();
+		} else {
+			$store = \SMW\ApplicationFactory::getInstance()->getStore();
+		}
+
 		$connection = $store->getConnection( "mw.db" );
 
 		$smw_title = $connection->addQuotes( str_replace( " ", "_", $title->getText() ) );

--- a/src/SearchEngine.php
+++ b/src/SearchEngine.php
@@ -25,7 +25,7 @@ use Elasticsearch\ClientBuilder;
 use Exception;
 use Hooks;
 use MediaWiki\MediaWikiServices;
-use NamespaceInfo;
+
 use WikiSearch\QueryEngine\Factory\QueryEngineFactory;
 use WikiSearch\QueryEngine\Filter\SearchTermFilter;
 use WikiSearch\QueryEngine\QueryEngine;
@@ -47,11 +47,6 @@ class SearchEngine {
 	private QueryEngine $query_engine;
 
 	/**
-	 * @var NamespaceInfo for finding canonical names;
-	 */
-	private NamespaceInfo $namespace_info;
-
-	/**
 	 * Search constructor.
 	 *
 	 * @param SearchEngineConfig $config
@@ -59,7 +54,6 @@ class SearchEngine {
 	public function __construct( SearchEngineConfig $config ) {
 		$this->config = $config;
 		$this->query_engine = QueryEngineFactory::fromSearchEngineConfig( $config );
-		$this->namespace_info = MediaWikiServices::getInstance()->getNamespaceInfo();
 	}
 
 	/**
@@ -178,7 +172,9 @@ class SearchEngine {
 
 			if ( $parts[0] === "namespace" ) {
 				foreach ( $results['aggregations'][$property_name]['buckets'] as $bucket_key => $bucket_value ) {
-					$namespace = $this->namespace_info->getCanonicalName( $bucket_value['key'] );
+					$namespace = MediaWikiServices::getInstance()
+						->getNamespaceInfo()
+						->getCanonicalName( $bucket_value['key'] );
 					$results['aggregations'][$property_name]['buckets'][$bucket_key]['name'] = $namespace;
 				}
 			}
@@ -196,7 +192,9 @@ class SearchEngine {
 	private function doNamespaceTranslations( array $results ): array {
 		// Translate namespace IDs to their canonical name
 		foreach ( $results['hits']['hits'] as $key => $value ) {
-			$namespace = $this->namespace_info->getCanonicalName( $value['_source']['subject']['namespace'] );
+			$namespace = MediaWikiServices::getInstance()
+				->getNamespaceInfo()
+				->getCanonicalName( $value['_source']['subject']['namespace'] );
 			$results['hits']['hits'][$key]['_source']['subject']['namespacename'] = $namespace;
 		}
 

--- a/src/SearchEngineConfig.php
+++ b/src/SearchEngineConfig.php
@@ -199,6 +199,7 @@ class SearchEngineConfig {
 			return new PropertyFieldMapper( $property_name );
 		}, $result_properties );
 
+		$this->facet_properties = [];
 		foreach ( $facet_properties as $property ) {
 			$translation_pair = explode( "=", $property );
 			$property_name = $translation_pair[0];
@@ -354,9 +355,9 @@ class SearchEngineConfig {
 		$page_id = $this->title->getArticleID();
 
 		$facet_properties = array_unique( array_map( function ( PropertyFieldMapper $property ): string {
-            // Use 'getPropertyName' here to make sure that the value in the database corresponds directly to the
-            // value present in the parser function call (otherwise it might be translated to something else, causing
-            // several problems in the front-end)
+			// Use 'getPropertyName' here to make sure that the value in the database corresponds directly to the
+			// value present in the parser function call (otherwise it might be translated to something else, causing
+			// several problems in the front-end)
 			return $property->getPropertyName();
 		}, $this->facet_properties ) );
 

--- a/src/WikiSearchHooks.php
+++ b/src/WikiSearchHooks.php
@@ -26,10 +26,10 @@ use ContentHandler;
 use DatabaseUpdater;
 use LogEntry;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Revision\RevisionRecord;
 use MWException;
 use OutputPage;
 use Parser;
-use Revision;
 use Skin;
 use SMW\PropertyRegistry;
 use SMW\SemanticData;
@@ -81,7 +81,7 @@ abstract class WikiSearchHooks {
 	 * @param mixed $is_watch
 	 * @param mixed $section
 	 * @param mixed $flags
-	 * @param Revision|null $revision Revision object of the saved content
+	 * @param RevisionRecord|null $revision Revision object of the saved content
 	 * @param Status $status Status object about to be returned by doEditContent()
 	 * @param mixed $original_revision_id
 	 * @param mixed $undid_revision_id
@@ -222,7 +222,7 @@ abstract class WikiSearchHooks {
 	 * @link https://www.mediawiki.org/wiki/Extension:Scribunto/Hooks/ScribuntoExternalLibraries
 	 *
 	 * @param string $engine
-	 * @param array &$extraLibraries
+	 * @param array $extraLibraries
 	 * @return bool
 	 */
 	public static function onScribuntoExternalLibraries( string $engine, array &$extraLibraries ): bool {
@@ -265,9 +265,9 @@ abstract class WikiSearchHooks {
 		}
 
 		$mwServices = MediaWikiServices::getInstance();
-		if (method_exists($mwServices, 'getContentRenderer')) {
+		if ( method_exists( $mwServices, 'getContentRenderer' ) ) {
 			// MW1.38+
-			$output = $mwServices->getContentRenderer()->getParserOutput($content, $subjectTitle);
+			$output = $mwServices->getContentRenderer()->getParserOutput( $content, $subjectTitle );
 		} else {
 			$output = $content->getParserOutput( $subjectTitle );
 		}


### PR DESCRIPTION
This pull request adds/changes:

- A fuzzy value filter;
- The PHP requirements from `^7.4` to `>= 7.4 < 8.3`;
- Improve `read` requirements for ApiQueryWikiSearchBase;
- A number of minor improvements.