### PR TITLE
Improve query preparation

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -3,7 +3,7 @@
 	"author": [
 		"Marijn van Wezel"
 	],
-	"version": "7.0.2",
+	"version": "8.0.0",
 	"url": "https://www.mediawiki.org/wiki/Extension:WikiSearch",
 	"descriptionmsg": "wikisearch-desc",
 	"license-name": "GPL-2.0-or-later",

--- a/extension.json
+++ b/extension.json
@@ -79,9 +79,6 @@
 		"WikiSearchMaxChainedQuerySize": {
 			"value": 500
 		},
-		"WikiSearchEscape": {
-			"value": false
-		},
 		"WikiSearchDisabledAnnotators": {
 			"value": []
 		}

--- a/src/QueryEngine/Filter/QueryPreparationTrait.php
+++ b/src/QueryEngine/Filter/QueryPreparationTrait.php
@@ -19,11 +19,6 @@ trait QueryPreparationTrait {
 	 * @return string
 	 */
 	public function prepareQuery( string $search_term ): string {
-		if ( !MediaWikiServices::getInstance()->getMainConfig()->get( 'WikiSearchEscape' ) ) {
-			// Escaping in the back-end is disabled
-			return $search_term;
-		}
-
 		$search_term = trim( $search_term );
 		$term_length = strlen( $search_term );
 


### PR DESCRIPTION
This pull request removes the `$wgWikiSearchEscape` configuration option, and moves all escaping to the backend.