### PR TITLE
Add max analyzer offset

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -3,7 +3,7 @@
 	"author": [
 		"Marijn van Wezel"
 	],
-	"version": "8.1.4",
+	"version": "8.1.5",
 	"url": "https://www.mediawiki.org/wiki/Extension:WikiSearch",
 	"descriptionmsg": "wikisearch-desc",
 	"license-name": "GPL-2.0-or-later",

--- a/src/QueryEngine/Highlighter/DefaultHighlighter.php
+++ b/src/QueryEngine/Highlighter/DefaultHighlighter.php
@@ -46,7 +46,8 @@ class DefaultHighlighter implements Highlighter {
 			$main_config = MediaWikiServices::getInstance()->getMainConfig();
 			$this->commonFieldSettings = [
 				"fragment_size" => $main_config->get( "WikiSearchHighlightFragmentSize" ),
-				"number_of_fragments" => $main_config->get( "WikiSearchHighlightNumberOfFragments" )
+				"number_of_fragments" => $main_config->get( "WikiSearchHighlightNumberOfFragments" ),
+                "max_analyzer_offset" => 1000000,
 			];
 		}
 	}


### PR DESCRIPTION
This fixes an issue where OpenSearch would crash when trying to generate highlights from extremely large fields.