### PR TITLE
Fix max_analyzer_offset typo in DefaultHighlighter

### DIFF
--- a/src/QueryEngine/Highlighter/DefaultHighlighter.php
+++ b/src/QueryEngine/Highlighter/DefaultHighlighter.php
@@ -47,7 +47,7 @@ class DefaultHighlighter implements Highlighter {
 			$this->commonFieldSettings = [
 				"fragment_size" => $main_config->get( "WikiSearchHighlightFragmentSize" ),
 				"number_of_fragments" => $main_config->get( "WikiSearchHighlightNumberOfFragments" ),
-                "max_analyzer_offset" => 1000000,
+                "max_analyzed_offset" => 1000000,
 			];
 		}
 	}


### PR DESCRIPTION
Fixes #84

`max_analyzer_offset` is not a valid Elasticsearch setting. The correct name is `max_analyzed_offset`.

See https://www.elastic.co/docs/reference/elasticsearch/rest-apis/highlighting-settings